### PR TITLE
Fix package name to assume @webcomponents/template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "template",
+  "name": "@webcomponents/template",
   "version": "0.0.1",
   "description": "Minimal template polyfills needed by webcomponents.js",
   "main": "template.js",


### PR DESCRIPTION
Fixes #9.

Since the name "template" is already taken, and the latest fills are using the `@webcomponents` scope, I'm updating this to assume the name this will be published under. We use this name as the dependency key and it fails when using NPM (Yarn works) unless we specify "template" as the key (which is actually incorrect because of existing package called "template").