### PR TITLE
Top-level option, thead, col, tr, td parsing

### DIFF
--- a/template.js
+++ b/template.js
@@ -131,17 +131,43 @@
           return o;
         },
         set: function(text) {
-          contentDoc.body.innerHTML = text;
+          var wrap = wrapMap(text);
+          var body = contentDoc.body;
+          body.innerHTML = wrap[1] + text + wrap[2];
           PolyfilledHTMLTemplateElement.bootstrap(contentDoc);
           while (this.content.firstChild) {
             this.content.removeChild(this.content.firstChild);
           }
-          while (contentDoc.body.firstChild) {
-            this.content.appendChild(contentDoc.body.firstChild);
+          var j = wrap[0];
+          while (j--) {
+            body = body.lastChild;
           }
+          while (body.firstChild) {
+            this.content.appendChild(body.firstChild);
+          }
+          // https://github.com/jquery/jquery/blob/a6b07052/src/manipulation/buildFragment.js#L59
+          body.textContent = "";
         },
         configurable: true
       });
+    }
+
+    function wrapMap(text) {
+      // https://github.com/jquery/jquery/blob/a6b07052/src/manipulation/wrapMap.js
+      var map = {
+        // Support: IE <=9 only
+        option: [ 1, "<select multiple='multiple'>", "</select>" ],
+        // XHTML parsers do not magically insert elements in the
+        // same way that tag soup parsers do. So we cannot shorten
+        // this by omitting <tbody> or other required elements.
+        thead: [ 1, "<table>", "</table>" ],
+        col: [ 2, "<table><colgroup>", "</colgroup></table>" ],
+        tr: [ 2, "<table><tbody>", "</tbody></table>" ],
+        td: [ 3, "<table><tbody><tr>", "</tr></tbody></table>" ]
+      };
+      // https://github.com/jquery/jquery/blob/a6b07052/src/manipulation/var/rtagName.js
+      var tag = ( /^\s*<([a-z][^\/\0>\x20\t\r\n\f]+)/i.exec(text) || [ "", "" ])[1].toLowerCase();
+      return map[tag] || [ 0, "", "" ];
     }
 
     defineInnerHTML(PolyfilledHTMLTemplateElement.prototype);

--- a/template.js
+++ b/template.js
@@ -166,7 +166,7 @@
         td: [ 3, "<table><tbody><tr>", "</tr></tbody></table>" ]
       };
       // https://github.com/jquery/jquery/blob/a6b07052/src/manipulation/var/rtagName.js
-      var tag = ( /^\s*<([a-z][^\/\0>\x20\t\r\n\f]+)/i.exec(text) || [ "", "" ])[1].toLowerCase();
+      var tag = ( /<([a-z][^\/\0>\x20\t\r\n\f]+)/i.exec(text) || [ "", "" ])[1].toLowerCase();
       return map[tag] || [ 0, "", "" ];
     }
 

--- a/tests/basic.html
+++ b/tests/basic.html
@@ -108,6 +108,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // innerHTML is properly escaped
           assert.equal(imp.innerHTML, escaped);
           assert.equal(imp.content.textContent, div.textContent);
+
+          s = '<tr><td>row</td></tr>';
+          imp.innerHTML = s;
+          assert.equal(imp.innerHTML, s);
+          assert.equal(imp.content.childNodes.length, 1);
+          assert.equal(imp.content.firstChild.nodeName, "TR");
+
+          s = '<option>label</option>';
+          imp.innerHTML = s;
+          assert.equal(imp.innerHTML, s);
+          assert.equal(imp.content.childNodes.length, 1);
+          assert.equal(imp.content.firstChild.nodeName, "OPTION");
+
+          s = '<td>one</td><td>two</td>';
+          imp.innerHTML = s;
+          assert.equal(imp.innerHTML, s);
+          assert.equal(imp.content.childNodes.length, 2);
+          assert.equal(imp.content.firstChild.nodeName, "TD");
         });
 
         test('clone', function() {

--- a/tests/basic.html
+++ b/tests/basic.html
@@ -126,6 +126,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(imp.innerHTML, s);
           assert.equal(imp.content.childNodes.length, 2);
           assert.equal(imp.content.firstChild.nodeName, "TD");
+
+          s = '<!--Comment--><tr><td>Content</td></tr>';
+          imp.innerHTML = s;
+          assert.equal(imp.innerHTML, s);
+
+          s = '<!--<tr><td>Comment</td></tr>--><tr><td>Content</td></tr>';
+          imp.innerHTML = s;
+          assert.equal(imp.innerHTML, s);
         });
 
         test('clone', function() {


### PR DESCRIPTION
This is a compatibility fix for IE <= 11, fixing #3.
I did not have the occasion to run the tests on actual IE because wct just stole my time :).