### PR TITLE
Workaround broken DocumentFragment in older versions of IE 11

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,13 @@
   "env": {
     "browser": true
   },
+  "plugins": [
+    "html"
+  ],
+  "rules": {
+    "semi": "error",
+    "strict": "error"
+  },
   "parserOptions": {
     "ecmaVersion": 5
   }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 dist: trusty
-node_js: 6
+node_js: stable
 addons:
   firefox: latest
   chrome: stable
@@ -12,7 +12,7 @@ before_script:
 script:
 - xvfb-run wct
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s 'windows 10/microsoftedge@14' -s 'windows 10/microsoftedge@15'
-  -s 'windows 8.1/internet explorer@11' -s 'os x 10.12/safari@10' -s 'os x 10.11/safari@9' -s 'Linux/chrome@41';
+  -s 'windows 8.1/internet explorer@11' -s 'os x 10.12/safari@11' -s 'os x 10.12/safari@10' -s 'os x 10.11/safari@9' -s 'Linux/chrome@41';
   fi
 env:
   global:

--- a/package.json
+++ b/package.json
@@ -16,12 +16,13 @@
     "url": "https://github.com/webcomponents/template/issues"
   },
   "scripts": {
-    "test": "wct",
-    "lint": "eslint template.js"
+    "test": "npm run lint && wct",
+    "lint": "eslint template.js test/**/*.html"
   },
   "homepage": "http://webcomponents.org",
   "devDependencies": {
     "eslint": "^4.8.0",
+    "eslint-plugin-html": "^3.2.2",
     "web-component-tester": "^6.3.0"
   },
   "publishConfig": {

--- a/template.js
+++ b/template.js
@@ -347,7 +347,9 @@
       for (var i=0, l=t$.length, t, s; i<l; i++) {
         s = s$[i];
         t = t$[i];
-        PolyfilledHTMLTemplateElement.decorate(s);
+        if (PolyfilledHTMLTemplateElement) {
+          PolyfilledHTMLTemplateElement.decorate(s);
+        }
         capturedReplaceChild.call(t.parentNode, cloneNode.call(s, true), t);
       }
     };

--- a/template.js
+++ b/template.js
@@ -347,9 +347,7 @@
       for (var i=0, l=t$.length, t, s; i<l; i++) {
         s = s$[i];
         t = t$[i];
-        if (this.decorate) {
-          PolyfilledHTMLTemplateElement.decorate(s);
-        }
+        PolyfilledHTMLTemplateElement.decorate(s);
         capturedReplaceChild.call(t.parentNode, cloneNode.call(s, true), t);
       }
     };

--- a/template.js
+++ b/template.js
@@ -347,7 +347,7 @@
       for (var i=0, l=t$.length, t, s; i<l; i++) {
         s = s$[i];
         t = t$[i];
-        if (PolyfilledHTMLTemplateElement) {
+        if (PolyfilledHTMLTemplateElement && PolyfilledHTMLTemplateElement.decorate) {
           PolyfilledHTMLTemplateElement.decorate(s);
         }
         capturedReplaceChild.call(t.parentNode, cloneNode.call(s, true), t);

--- a/template.js
+++ b/template.js
@@ -348,7 +348,7 @@
         s = s$[i];
         t = t$[i];
         if (this.decorate) {
-          this.decorate(s);
+          PolyfilledHTMLTemplateElement.decorate(s);
         }
         capturedReplaceChild.call(t.parentNode, cloneNode.call(s, true), t);
       }

--- a/template.js
+++ b/template.js
@@ -27,15 +27,11 @@
 
       var origCloneNode = Node.prototype.cloneNode;
       Node.prototype.cloneNode = function cloneNode(deep) {
+        var newDom = origCloneNode.call(this, deep);
         if (this instanceof DocumentFragment) {
-          var newFrag = origCloneNode.call(this, deep);
-          if (this instanceof DocumentFragment) {
-            newFrag.__proto__ = DocumentFragment.prototype;
-          }
-          return newFrag;
-        } else {
-          return origCloneNode.call(this, deep);
+          newDom.__proto__ = DocumentFragment.prototype;
         }
+        return newDom;
       };
 
       // IE's DocumentFragment querySelector code doesn't work when
@@ -331,7 +327,7 @@
         // cloneNode does not cause elements to upgrade.
         capturedAppendChild.call(clone.content, capturedCloneNode.call(template.content, true));
         // now ensure nested templates are cloned correctly.
-        this._fixClonedDom(clone.content, template.content);
+        fixClonedDom(clone.content, template.content);
       }
       return clone;
     };
@@ -339,7 +335,7 @@
     // Given a source and cloned subtree, find <template>'s in the cloned
     // subtree and replace them with cloned <template>'s from source.
     // We must do this because only the source templates have proper .content.
-    PolyfilledHTMLTemplateElement._fixClonedDom = function _fixClonedDom(clone, source) {
+    var fixClonedDom = function fixClonedDom(clone, source) {
       // do nothing if cloned node is not an element
       if (!source.querySelectorAll) return;
       // these two lists should be coincident
@@ -377,7 +373,7 @@
       }
       // template.content is cloned iff `deep`.
       if (deep) {
-        PolyfilledHTMLTemplateElement._fixClonedDom(dom, this);
+        fixClonedDom(dom, this);
       }
       return dom;
     };
@@ -394,7 +390,7 @@
       } else {
         var dom = capturedImportNode.call(this, element, deep);
         if (deep) {
-          PolyfilledHTMLTemplateElement._fixClonedDom(dom, element);
+          fixClonedDom(dom, element);
         }
         return dom;
       }

--- a/template.js
+++ b/template.js
@@ -22,17 +22,13 @@
     (function() {
 
       var Native_cloneNode = Node.prototype.cloneNode;
-      var docFragCloneNode = DocumentFragment.prototype.cloneNode = function cloneNode(deep) {
-        var newFrag = Native_cloneNode.call(this, deep);
-        if (this instanceof DocumentFragment) {
-          newFrag.__proto__ = DocumentFragment.prototype;
-        }
-        return newFrag;
-      };
-
       Node.prototype.cloneNode = function cloneNode(deep) {
         if (this instanceof DocumentFragment) {
-          return docFragCloneNode.call(this, deep);
+          var newFrag = Native_cloneNode.call(this, deep);
+          if (this instanceof DocumentFragment) {
+            newFrag.__proto__ = DocumentFragment.prototype;
+          }
+          return newFrag;
         } else {
           return Native_cloneNode.call(this, deep);
         }
@@ -113,14 +109,14 @@
       // children may have null out parentNode.
       // Just create a new DocumentFragment in this case
       var Native_importNode = Document.prototype.importNode;
-      function importNode(impNode, deep) {
+      Document.prototype.importNode = function importNode(impNode, deep) {
+        deep = deep || false;
         var newNode = Native_importNode.call(this, impNode, deep);
         if (impNode instanceof DocumentFragment) {
           newNode.__proto__ = DocumentFragment.prototype;
         }
         return newNode;
-      }
-      Document.prototype.importNode = importNode;
+      };
     })();
   }
 
@@ -378,6 +374,7 @@
     // subtree and `fixClonedDom` inserts cloned templates into this subtree,
     // thus updating the owner doc.
     Document.prototype.importNode = function(element, deep) {
+      deep = deep || false;
       if (element.localName === TEMPLATE_TAG) {
         return PolyfilledHTMLTemplateElement._cloneNode(element, deep);
       } else {

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "assert": true,
+    "sinon": true,
+    "WCT": true,
+    "fixture": true
+  }
+}

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -2,6 +2,9 @@
   "env": {
     "mocha": true
   },
+  "rules": {
+    "strict": "off"
+  },
   "globals": {
     "assert": true,
     "sinon": true,

--- a/tests/basic.html
+++ b/tests/basic.html
@@ -79,7 +79,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('stamping', function() {
           document.body.appendChild(document.importNode(template.content, true));
-          content = document.querySelector('#content');
+          var content = document.querySelector('#content');
           assert.isDefined(content, 'template content stamped into document');
         });
 
@@ -161,7 +161,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           setupTemplate(t, s);
           imp.appendChild(t);
           var impClone = imp.cloneNode(true);
-          var imp = imp.firstChild;
+          imp = imp.firstChild;
           var deepClone = impClone.firstChild;
           assert.equal(deepClone.content.childNodes.length, 2,
               'deep cloned template.content is empty');

--- a/tests/document-fragment.html
+++ b/tests/document-fragment.html
@@ -66,9 +66,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var child = otherDoc.createElement('div');
           child.innerHTML = '<span>foo!</span>';
           frag.appendChild(child);
-          var newFrag = document.importNode(frag);
-          assert.equal(newFrag.ownerDocument, document);
-          assert.equal(newFrag.childNodes.length, 0);
+          var newFrag;
+          // Edge 14 throws NotSupportedError with importNode(docFrag, false) for some reason
+          if (!navigator.userAgent.match('Edge/14')) {
+            newFrag = document.importNode(frag, false);
+            assert.equal(newFrag.ownerDocument, document);
+            assert.equal(newFrag.childNodes.length, 0);
+          }
           newFrag = document.importNode(frag, true);
           assert.equal(newFrag.childNodes.length, 1);
           assert.equal(newFrag.childNodes[0].innerHTML, '<span>foo!</span>');

--- a/tests/document-fragment.html
+++ b/tests/document-fragment.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <title>Template Test</title>
+    <script src="../template.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+  </head>
+  <body>
+    <script>
+      suite('Document Fragment', function() {
+        test('createDocumentFragment', function() {
+          var frag = document.createDocumentFragment();
+          assert.equal(frag.nodeType, Node.DOCUMENT_FRAGMENT_NODE);
+          assert.instanceOf(frag, DocumentFragment);
+        });
+
+        test('localName', function() {
+          var frag = document.createDocumentFragment();
+          // may be null or undefined depending on browser vendor
+          assert(frag.localName == null);
+        });
+
+        test('nodeType', function() {
+          var frag = document.createDocumentFragment();
+          assert.equal(frag.nodeType, Node.DOCUMENT_FRAGMENT_NODE);
+        });
+
+        test('nodeName', function() {
+          var frag = document.createDocumentFragment();
+          assert.equal(frag.nodeName, '#document-fragment');
+        });
+
+        test('tagName', function() {
+          var frag = document.createDocumentFragment();
+          assert(frag.tagName == null);
+        });
+
+        test('cloneNode', function() {
+          var frag = document.createDocumentFragment();
+          var child = document.createElement('div');
+          var grandChild = document.createElement('span');
+          grandChild.textContent = 'Hi!';
+          child.appendChild(grandChild);
+          frag.appendChild(child);
+          var clone = frag.cloneNode();
+          assert.equal(frag.childNodes.length, 1);
+          assert.equal(clone.childNodes.length, 0);
+          clone = frag.cloneNode(true);
+          assert.equal(clone.childNodes.length, 1);
+          assert.equal(clone.firstChild.childNodes.length, 1);
+          assert.equal(clone.firstChild.firstChild.textContent, 'Hi!');
+        });
+
+        test('importNode', function() {
+          var otherDoc = document.implementation.createHTMLDocument('other');
+          var frag = otherDoc.createDocumentFragment();
+          var child = otherDoc.createElement('div');
+          child.innerHTML = '<span>foo!</span>';
+          frag.appendChild(child);
+          var newFrag = document.importNode(frag);
+          assert.equal(newFrag.ownerDocument, document);
+          assert.equal(newFrag.childNodes.length, 0);
+          newFrag = document.importNode(frag, true);
+          assert.equal(newFrag.childNodes.length, 1);
+          assert.equal(newFrag.childNodes[0].innerHTML, '<span>foo!</span>');
+        });
+
+        test('appendChild with DocumentFragment', function() {
+          var div = document.createElement('div');
+          var frag = document.createDocumentFragment();
+          var child = document.createElement('div');
+          child.innerHTML = '<span>foo!</span>';
+          frag.appendChild(child);
+          div.appendChild(frag);
+          assert.equal(div.innerHTML, '<div><span>foo!</span></div>');
+        });
+
+        test('insertBefore with DocumentFragment', function() {
+          var div = document.createElement('div');
+          var frag = document.createDocumentFragment();
+          var child = document.createElement('div');
+          child.innerHTML = '<span>foo!</span>';
+          frag.appendChild(child);
+          div.innerHTML = '<bar></bar>';
+          div.insertBefore(frag, div.firstChild);
+          assert.equal(div.innerHTML, '<div><span>foo!</span></div><bar></bar>');
+        });
+
+        test('replaceChild with DocumentFragment', function() {
+          var div = document.createElement('div');
+          var frag = document.createDocumentFragment();
+          var child = document.createElement('div');
+          child.innerHTML = '<span>foo!</span>';
+          frag.appendChild(child);
+          div.innerHTML = '<bar></bar>';
+          div.replaceChild(frag, div.firstChild);
+          assert.equal(div.innerHTML, '<div><span>foo!</span></div>');
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/tests/runner.html
+++ b/tests/runner.html
@@ -15,7 +15,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
   var suites = [
-    'basic.html'
+    'basic.html',
+    'document-fragment.html'
   ];
 
   WCT.loadSuites(suites);


### PR DESCRIPTION
In these old versions of IE 11, modifying a DocumentFragment while a
MutationObserver is active could leave the childNodes of the
DocumentFragment with either a `null` parentNode, or a parentNode
pointing to a new DocumentFragment wrapper that is not identical to the
current one, but shares prototypical values like `childNodes`.

This can lead to instances where `frag.firstChild.parentNode !== frag`,
but `frag.firstChild.parentNode.childNodes === frag.childNodes`.
Eventually, this new wrapper is GC'd and the parentNode will be null,
causing all sorts of SUPER FUN PROBLEMS.