### PR TITLE
More correct innerHTML getter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
 - npm run lint
 script:
 - xvfb-run wct
-- if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s 'windows 10/microsoftedge@14' -s 'windows 10/microsoftedge@15'
+- if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s 'windows 10/microsoftedge@14' -s 'windows 10/microsoftedge@15' -s 'windows 10/microsoftedge@16'
   -s 'windows 8.1/internet explorer@11' -s 'os x 10.12/safari@11' -s 'os x 10.12/safari@10' -s 'os x 10.11/safari@9' -s 'Linux/chrome@41';
   fi
 env:

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   },
   "homepage": "http://webcomponents.org",
   "devDependencies": {
-    "eslint": "^4.8.0",
-    "eslint-plugin-html": "^3.2.2",
-    "web-component-tester": "^6.3.0"
+    "eslint": "^4.19.0",
+    "eslint-plugin-html": "^4.0.2",
+    "web-component-tester": "^6.5.0"
   },
   "publishConfig": {
     "access": "public"

--- a/template.js
+++ b/template.js
@@ -229,11 +229,7 @@
     var defineInnerHTML = function defineInnerHTML(obj) {
       Object.defineProperty(obj, 'innerHTML', {
         get: function() {
-          var o = '';
-          for (var e = this.content.firstChild; e; e = e.nextSibling) {
-            o += e.outerHTML || escapeData(e.data);
-          }
-          return o;
+          return getInnerHTML(this);
         },
         set: function(text) {
           contentDoc.body.innerHTML = text;
@@ -298,9 +294,11 @@
       return el;
     };
 
-    var escapeDataRegExp = /[&\u00A0<>]/g;
+    // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#escapingString
+    let escapeAttrRegExp = /[&\u00A0"]/g;
+    let escapeDataRegExp = /[&\u00A0<>]/g;
 
-    var escapeReplace = function escapeReplace(c) {
+    function escapeReplace(c) {
       switch (c) {
         case '&':
           return '&amp;';
@@ -308,14 +306,113 @@
           return '&lt;';
         case '>':
           return '&gt;';
+        case '"':
+          return '&quot;';
         case '\u00A0':
           return '&nbsp;';
       }
-    };
+    }
 
-    var escapeData = function escapeData(s) {
+    function escapeAttr(s) {
+      return s.replace(escapeAttrRegExp, escapeReplace);
+    }
+
+    function escapeData(s) {
       return s.replace(escapeDataRegExp, escapeReplace);
-    };
+    }
+
+    function makeSet(arr) {
+      let set = {};
+      for (let i = 0; i < arr.length; i++) {
+        set[arr[i]] = true;
+      }
+      return set;
+    }
+
+    // http://www.whatwg.org/specs/web-apps/current-work/#void-elements
+    let voidElements = makeSet([
+      'area',
+      'base',
+      'br',
+      'col',
+      'command',
+      'embed',
+      'hr',
+      'img',
+      'input',
+      'keygen',
+      'link',
+      'meta',
+      'param',
+      'source',
+      'track',
+      'wbr'
+    ]);
+
+    let plaintextParents = makeSet([
+      'style',
+      'script',
+      'xmp',
+      'iframe',
+      'noembed',
+      'noframes',
+      'plaintext',
+      'noscript'
+    ]);
+
+    /**
+     * @param {Node} node
+     * @param {Node} parentNode
+     * @param {Function=} callback
+     */
+    function getOuterHTML(node, parentNode, callback) {
+      switch (node.nodeType) {
+        case Node.ELEMENT_NODE: {
+          let tagName = node.localName;
+          let s = '<' + tagName;
+          let attrs = node.attributes;
+          for (let i = 0, attr; (attr = attrs[i]); i++) {
+            s += ' ' + attr.name + '="' + escapeAttr(attr.value) + '"';
+          }
+          s += '>';
+          if (voidElements[tagName]) {
+            return s;
+          }
+          return s + getInnerHTML(node, callback) + '</' + tagName + '>';
+        }
+        case Node.TEXT_NODE: {
+          let data = /** @type {Text} */ (node).data;
+          if (parentNode && plaintextParents[parentNode.localName]) {
+            return data;
+          }
+          return escapeData(data);
+        }
+        case Node.COMMENT_NODE: {
+          return '<!--' + /** @type {Comment} */ (node).data + '-->';
+        }
+        default: {
+          window.console.error(node);
+          throw new Error('not implemented');
+        }
+      }
+    }
+
+    /**
+     * @param {Node} node
+     * @param {Function=} callback
+     */
+    function getInnerHTML(node, callback) {
+      if (node.localName === 'template') {
+        node =  /** @type {HTMLTemplateElement} */ (node).content;
+      }
+      let s = '';
+      let c$ = callback ? callback(node) : node.childNodes;
+      for (let i=0, l=c$.length, child; (i<l) && (child=c$[i]); i++) {
+        s += getOuterHTML(child, node, callback);
+      }
+      return s;
+    }
+
   }
 
   // make cloning/importing work!

--- a/template.js
+++ b/template.js
@@ -295,8 +295,8 @@
     };
 
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#escapingString
-    let escapeAttrRegExp = /[&\u00A0"]/g;
-    let escapeDataRegExp = /[&\u00A0<>]/g;
+    var escapeAttrRegExp = /[&\u00A0"]/g;
+    var escapeDataRegExp = /[&\u00A0<>]/g;
 
     function escapeReplace(c) {
       switch (c) {
@@ -322,15 +322,15 @@
     }
 
     function makeSet(arr) {
-      let set = {};
-      for (let i = 0; i < arr.length; i++) {
+      var set = {};
+      for (var i = 0; i < arr.length; i++) {
         set[arr[i]] = true;
       }
       return set;
     }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#void-elements
-    let voidElements = makeSet([
+    var voidElements = makeSet([
       'area',
       'base',
       'br',
@@ -349,7 +349,7 @@
       'wbr'
     ]);
 
-    let plaintextParents = makeSet([
+    var plaintextParents = makeSet([
       'style',
       'script',
       'xmp',
@@ -368,10 +368,10 @@
     function getOuterHTML(node, parentNode, callback) {
       switch (node.nodeType) {
         case Node.ELEMENT_NODE: {
-          let tagName = node.localName;
-          let s = '<' + tagName;
-          let attrs = node.attributes;
-          for (let i = 0, attr; (attr = attrs[i]); i++) {
+          var tagName = node.localName;
+          var s = '<' + tagName;
+          var attrs = node.attributes;
+          for (var i = 0, attr; (attr = attrs[i]); i++) {
             s += ' ' + attr.name + '="' + escapeAttr(attr.value) + '"';
           }
           s += '>';
@@ -381,7 +381,7 @@
           return s + getInnerHTML(node, callback) + '</' + tagName + '>';
         }
         case Node.TEXT_NODE: {
-          let data = /** @type {Text} */ (node).data;
+          var data = /** @type {Text} */ (node).data;
           if (parentNode && plaintextParents[parentNode.localName]) {
             return data;
           }
@@ -405,9 +405,9 @@
       if (node.localName === 'template') {
         node =  /** @type {HTMLTemplateElement} */ (node).content;
       }
-      let s = '';
-      let c$ = callback ? callback(node) : node.childNodes;
-      for (let i=0, l=c$.length, child; (i<l) && (child=c$[i]); i++) {
+      var s = '';
+      var c$ = callback ? callback(node) : node.childNodes;
+      for (var i=0, l=c$.length, child; (i<l) && (child=c$[i]); i++) {
         s += getOuterHTML(child, node, callback);
       }
       return s;

--- a/template.js
+++ b/template.js
@@ -298,7 +298,7 @@
     var escapeAttrRegExp = /[&\u00A0"]/g;
     var escapeDataRegExp = /[&\u00A0<>]/g;
 
-    function escapeReplace(c) {
+    var escapeReplace = function(c) {
       switch (c) {
         case '&':
           return '&amp;';
@@ -311,23 +311,23 @@
         case '\u00A0':
           return '&nbsp;';
       }
-    }
+    };
 
-    function escapeAttr(s) {
+    var escapeAttr = function(s) {
       return s.replace(escapeAttrRegExp, escapeReplace);
-    }
+    };
 
-    function escapeData(s) {
+    var escapeData = function(s) {
       return s.replace(escapeDataRegExp, escapeReplace);
-    }
+    };
 
-    function makeSet(arr) {
+    var makeSet = function(arr) {
       var set = {};
       for (var i = 0; i < arr.length; i++) {
         set[arr[i]] = true;
       }
       return set;
-    }
+    };
 
     // http://www.whatwg.org/specs/web-apps/current-work/#void-elements
     var voidElements = makeSet([
@@ -365,7 +365,7 @@
      * @param {Node} parentNode
      * @param {Function=} callback
      */
-    function getOuterHTML(node, parentNode, callback) {
+    var getOuterHTML = function(node, parentNode, callback) {
       switch (node.nodeType) {
         case Node.ELEMENT_NODE: {
           var tagName = node.localName;
@@ -395,13 +395,13 @@
           throw new Error('not implemented');
         }
       }
-    }
+    };
 
     /**
      * @param {Node} node
      * @param {Function=} callback
      */
-    function getInnerHTML(node, callback) {
+    var getInnerHTML = function(node, callback) {
       if (node.localName === 'template') {
         node =  /** @type {HTMLTemplateElement} */ (node).content;
       }
@@ -411,7 +411,7 @@
         s += getOuterHTML(child, node, callback);
       }
       return s;
-    }
+    };
 
   }
 

--- a/tests/basic.html
+++ b/tests/basic.html
@@ -110,6 +110,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(imp.content.textContent, div.textContent);
         });
 
+        test('innerHTML (nested)', function() {
+          if (!canInnerHTML) {
+            this.skip();
+          }
+          var imp = document.createElement('template');
+          assert.equal(imp.innerHTML, '');
+          var s = 'pre<div><template>Hi</template></div><div><template>Bye</template></div>post';
+          imp.innerHTML = s;
+          assert.equal(imp.innerHTML, s);
+        });
+
         test('clone', function() {
           var imp = document.createElement('template');
           var s = '<div>Hi</div>';

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -2,5 +2,14 @@
   "suites": ["tests/runner.html"],
   "clientOptions": {
     "environmentImports": []
+  },
+  "plugins": {
+    "local": {
+      "browserOptions": {
+        "chrome": [
+          "no-sandbox"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes #32 by making `innerHTML` getter recurse so that nested templates are handled correctly.