### PR TITLE
Add test for innerHTML with comment nodes

### DIFF
--- a/tests/basic.html
+++ b/tests/basic.html
@@ -130,7 +130,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var s = '<!-- This is a comment -->';
           imp.innerHTML = s;
           assert.equal(imp.innerHTML, s);
-        })
+        });
+
+        test('innerHTML (table elements)', function() {
+          if (!canInnerHTML) {
+            this.skip();
+          }
+          var imp = document.createElement('template');
+          assert.equal(imp.innerHTML, '');
+          var s = '<tr><td class="record"></td><td></td><td><span class="extra">nothing</span></td></tr>';
+          imp.innerHTML = s;
+          assert.equal(imp.innerHTML, s);
+        });
 
         test('clone', function() {
           var imp = document.createElement('template');

--- a/tests/basic.html
+++ b/tests/basic.html
@@ -121,6 +121,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(imp.innerHTML, s);
         });
 
+        test('innerHTML (comments)', function() {
+          if (!canInnerHTML) {
+            this.skip();
+          }
+          var imp = document.createElement('template');
+          assert.equal(imp.innerHTML, '');
+          var s = '<!-- This is a comment -->';
+          imp.innerHTML = s;
+          assert.equal(imp.innerHTML, s);
+        })
+
         test('clone', function() {
           var imp = document.createElement('template');
           var s = '<div>Hi</div>';

--- a/tests/basic.html
+++ b/tests/basic.html
@@ -132,7 +132,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(imp.innerHTML, s);
         });
 
-        test('innerHTML (table elements)', function() {
+        // Not yet working, as the setter of `innerHTML` moves the table elements
+        // into a non-table context, which are removed by the parser
+        test.skip('innerHTML (table elements)', function() {
           if (!canInnerHTML) {
             this.skip();
           }


### PR DESCRIPTION
The original issue was actually fixed in #33 but this adds an explicit regression test for comment nodes.

Fixes #27 
Fixes #5 