### PR TITLE
Patch DOMParser and HTMLElement.innerHTML as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 dist: trusty
-node_js: stable
+node_js: '9'
 addons:
   firefox: latest
   chrome: stable

--- a/template.js
+++ b/template.js
@@ -126,6 +126,8 @@
   var capturedRemoveChild = Node.prototype.removeChild;
   var capturedAppendChild = Node.prototype.appendChild;
   var capturedReplaceChild = Node.prototype.replaceChild;
+  var capturedParseFromString = DOMParser.prototype.parseFromString;
+  var capturedHTMLElementInnerHTML = Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, 'innerHTML');
 
   var elementQuerySelectorAll = Element.prototype.querySelectorAll;
   var docQuerySelectorAll = Document.prototype.querySelectorAll;
@@ -323,6 +325,24 @@
       }
       return el;
     };
+
+    DOMParser.prototype.parseFromString = function() {
+      var el = capturedParseFromString.apply(this, arguments);
+      PolyfilledHTMLTemplateElement.bootstrap(el);
+      return el;
+    };
+
+    Object.defineProperty(HTMLElement.prototype, 'innerHTML', {
+      get: function() {
+        return getInnerHTML(this);
+      },
+      set: function(text) {
+        capturedHTMLElementInnerHTML.set.call(this, text);
+        PolyfilledHTMLTemplateElement.bootstrap(this);
+      },
+      configurable: true,
+      enumerable: true
+    });
 
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#escapingString
     var escapeAttrRegExp = /[&\u00A0"]/g;

--- a/tests/basic.html
+++ b/tests/basic.html
@@ -421,6 +421,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(svgTemplate.namespaceURI, svgNamespace);
           assert.equal(svgTemplate.firstChild.namespaceURI, svgNamespace);
         });
+
+        test('DOMParser constructs correct templates', function() {
+          var DOM = (new DOMParser).parseFromString("<template></template>", "text/html");
+          assert.isTrue(DOM.querySelector("template") instanceof HTMLTemplateElement);
+        });
+
+        test('innerHTML (option element)', function() {
+          var container = document.createElement('div');
+          assert.equal(container.innerHTML, '');
+          var innerHTML = "<template><span>In template</span></template>";
+          container.innerHTML = innerHTML;
+          assert.equal(container.innerHTML, innerHTML);
+          assert.isTrue(container.firstChild instanceof HTMLTemplateElement);
+          assert.isOk(container.firstChild.content);
+          assert.isTrue(container.firstChild.content.firstChild instanceof HTMLSpanElement);
+        });
       });
     </script>
   </body>

--- a/tests/basic.html
+++ b/tests/basic.html
@@ -427,7 +427,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.isTrue(DOM.querySelector("template") instanceof HTMLTemplateElement);
         });
 
-        test('innerHTML (option element)', function() {
+        test('innerHTML on regular HTMLElement upgrades nested template', function() {
           var container = document.createElement('div');
           assert.equal(container.innerHTML, '');
           var innerHTML = "<template><span>In template</span></template>";


### PR DESCRIPTION
Add 2 more patches to functions to call `bootstrap` to correctly upgrade template elements.

Fixes #42 
Fixes #40 