### PR TITLE
fallbacks for older browsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
 script:
 - xvfb-run wct --npm
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct --npm -s 'windows 10/microsoftedge@13' -s 'windows 10/microsoftedge@14' -s 'windows 10/microsoftedge@15' -s 'windows 10/microsoftedge@16'
-  -s 'windows 8.1/internet explorer@11' -s 'os x 10.12/safari@11' -s 'os x 10.12/safari@10' -s 'os x 10.11/safari@9' -s 'Linux/chrome@41';
+  -s 'windows 8.1/internet explorer@11' -s 'macos 10.13/safari@11' -s 'os x 10.12/safari@10' -s 'os x 10.11/safari@9' -s 'Linux/chrome@41';
   fi
 env:
   global:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,169 +5,77 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz",
-      "integrity": "sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.54.tgz",
+      "integrity": "sha1-ACT5b99wKKIdaOJzr9TpUyFKHq0=",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.49"
+        "@babel/highlight": "7.0.0-beta.54"
       }
     },
     "@babel/core": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.49.tgz",
-      "integrity": "sha1-c94ggd1lJIlInwy0qpeCmhEzMU4=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.54.tgz",
+      "integrity": "sha1-JTxU0AlUA6XPp2Tn2bRYGUaS0Cs=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.49",
-        "@babel/generator": "7.0.0-beta.49",
-        "@babel/helpers": "7.0.0-beta.49",
-        "@babel/parser": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
-        "convert-source-map": "^1.1.0",
-        "debug": "^3.1.0",
-        "json5": "^0.5.0",
-        "lodash": "^4.17.5",
-        "micromatch": "^2.3.11",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        }
+        "@babel/code-frame": "7.0.0-beta.54",
+        "@babel/generator": "7.0.0-beta.54",
+        "@babel/helpers": "7.0.0-beta.54",
+        "@babel/parser": "7.0.0-beta.54",
+        "@babel/template": "7.0.0-beta.54",
+        "@babel/traverse": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54",
+        "convert-source-map": "1.5.1",
+        "debug": "3.1.0",
+        "json5": "0.5.1",
+        "lodash": "4.17.10",
+        "resolve": "1.8.1",
+        "semver": "5.5.0",
+        "source-map": "0.5.7"
       }
     },
     "@babel/generator": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.49.tgz",
-      "integrity": "sha1-6c/9qROZaszseTu8JauRvBnQv3o=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.54.tgz",
+      "integrity": "sha1-wEPH7r7r/X5mXZXCgaSq/IPU4ck=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.5",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "@babel/types": "7.0.0-beta.54",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.49.tgz",
-      "integrity": "sha1-fZAF1U/nrWy4dnkCUedVdUGRhuk=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.54.tgz",
+      "integrity": "sha1-FiYSaj+fxO0oCslCNyx9OWU9cSE=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/types": "7.0.0-beta.54"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.49.tgz",
-      "integrity": "sha1-xi3VBCtUpZDV5x5gIMRrkdbGyHU=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.54.tgz",
+      "integrity": "sha1-0KGWdjW57ryv26gEkZF+5JgcEvo=",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/helper-explode-assignable-expression": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54"
       }
     },
     "@babel/helper-call-delegate": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.49.tgz",
-      "integrity": "sha1-S11BeCpoPV3GSXg0oyMQqNAqOvk=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.54.tgz",
+      "integrity": "sha1-9rcs/YMvsm6yqAbhjeBfiNOo8wI=",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "7.0.0-beta.49",
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/helper-hoist-variables": "7.0.0-beta.54",
+        "@babel/traverse": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54"
       }
     },
     "@babel/helper-define-map": {
@@ -178,7 +86,7 @@
       "requires": {
         "@babel/helper-function-name": "7.0.0-beta.35",
         "@babel/types": "7.0.0-beta.35",
-        "lodash": "^4.2.0"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -187,9 +95,9 @@
           "integrity": "sha512-l0SE8cl9DUIY4hYAFAKTLX3F2Yr14Qri7uTsuI7iegB5E4KyQy4XY72L3VOxmj6kwR/RDQURoKYr2NzyETGo7A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
+            "chalk": "2.4.1",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
           }
         },
         "@babel/helper-function-name": {
@@ -221,7 +129,7 @@
             "@babel/code-frame": "7.0.0-beta.35",
             "@babel/types": "7.0.0-beta.35",
             "babylon": "7.0.0-beta.35",
-            "lodash": "^4.2.0"
+            "lodash": "4.17.10"
           }
         },
         "@babel/types": {
@@ -230,9 +138,9 @@
           "integrity": "sha512-y9XT11CozHDgjWcTdxmhSj13rJVXpa5ZXwjjOiTedjaM0ba5ItqdS02t31EhPl7HtOWxsZkYCCUNrSfrOisA6w==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.2.0",
-            "to-fast-properties": "^2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "2.0.0"
           }
         },
         "babylon": {
@@ -244,75 +152,75 @@
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.49.tgz",
-      "integrity": "sha1-K/uV337BMHNb9lXkSiF6cNOxPpM=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.54.tgz",
+      "integrity": "sha1-zwZ/MzCWXCBIvwh+oG9ix22Up5I=",
       "dev": true,
       "requires": {
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/traverse": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.49.tgz",
-      "integrity": "sha1-olwRGbnwNSeGcBJuAiXAMEHI3jI=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.54.tgz",
+      "integrity": "sha1-MHh1UHoe2iSCoJqaTfaiVjL/s0s=",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/helper-get-function-arity": "7.0.0-beta.54",
+        "@babel/template": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.49.tgz",
-      "integrity": "sha1-z1Aj8y0q2S0Ic3STnOwJUby1FEE=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.54.tgz",
+      "integrity": "sha1-dXvRibB3B0oAQCjP3l8IPDBsxsQ=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/types": "7.0.0-beta.54"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.49.tgz",
-      "integrity": "sha1-2XQGUck7tPp5wba6xjQFH8TQP/U=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.54.tgz",
+      "integrity": "sha1-hjW+gJUTX/c/dT7RieRJ9otPQ8s=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/types": "7.0.0-beta.54"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.49.tgz",
-      "integrity": "sha1-L2QrAD1FFV4KnnpK0OaI2Ru8FYM=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.54.tgz",
+      "integrity": "sha1-vOndxIQxexPSYVuv4rUk0NVtmd8=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/types": "7.0.0-beta.54"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.49.tgz",
-      "integrity": "sha1-QdfVmJEBbEk0MqRvdGREZVKJDHU=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.54.tgz",
+      "integrity": "sha1-wtjhT/A0Ilv0MTVtt370Z7jTWqw=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49",
-        "lodash": "^4.17.5"
+        "@babel/types": "7.0.0-beta.54",
+        "lodash": "4.17.10"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.49.tgz",
-      "integrity": "sha1-/GYL2p1kl0EuGHdqca7ZqeLl960=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.54.tgz",
+      "integrity": "sha1-jMV+sNtfCUXYZlJNVVq9CE4wzDU=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.49",
-        "@babel/helper-simple-access": "7.0.0-beta.49",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
-        "lodash": "^4.17.5"
+        "@babel/helper-module-imports": "7.0.0-beta.54",
+        "@babel/helper-simple-access": "7.0.0-beta.54",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.54",
+        "@babel/template": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54",
+        "lodash": "4.17.10"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -330,39 +238,39 @@
           "integrity": "sha512-y9XT11CozHDgjWcTdxmhSj13rJVXpa5ZXwjjOiTedjaM0ba5ItqdS02t31EhPl7HtOWxsZkYCCUNrSfrOisA6w==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.2.0",
-            "to-fast-properties": "^2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "2.0.0"
           }
         }
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.49.tgz",
-      "integrity": "sha1-Dp/LuDT4eLs2XSqOqQ7uIbo8zSM=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.54.tgz",
+      "integrity": "sha1-YdKpoPmj4xg4pFjeu57r173SSbQ=",
       "dev": true
     },
     "@babel/helper-regex": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.49.tgz",
-      "integrity": "sha1-/yRPGcKi8Wf/SzFlpjawj9ZBgWs=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.54.tgz",
+      "integrity": "sha1-isVi+FXxMvxo39ELEyVSVVrIcNk=",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.5"
+        "lodash": "4.17.10"
       }
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.49.tgz",
-      "integrity": "sha1-s/2qtBJ4TX6GV7rKsoaSPvyUmLg=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.54.tgz",
+      "integrity": "sha1-OaUAUqrddNQMc7fFjrljuQ+sVtM=",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.49",
-        "@babel/helper-wrap-function": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.54",
+        "@babel/helper-wrap-function": "7.0.0-beta.54",
+        "@babel/template": "7.0.0-beta.54",
+        "@babel/traverse": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54"
       }
     },
     "@babel/helper-replace-supers": {
@@ -383,9 +291,9 @@
           "integrity": "sha512-l0SE8cl9DUIY4hYAFAKTLX3F2Yr14Qri7uTsuI7iegB5E4KyQy4XY72L3VOxmj6kwR/RDQURoKYr2NzyETGo7A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
+            "chalk": "2.4.1",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
           }
         },
         "@babel/helper-function-name": {
@@ -417,7 +325,7 @@
             "@babel/code-frame": "7.0.0-beta.35",
             "@babel/types": "7.0.0-beta.35",
             "babylon": "7.0.0-beta.35",
-            "lodash": "^4.2.0"
+            "lodash": "4.17.10"
           }
         },
         "@babel/traverse": {
@@ -430,10 +338,10 @@
             "@babel/helper-function-name": "7.0.0-beta.35",
             "@babel/types": "7.0.0-beta.35",
             "babylon": "7.0.0-beta.35",
-            "debug": "^3.0.1",
-            "globals": "^10.0.0",
-            "invariant": "^2.2.0",
-            "lodash": "^4.2.0"
+            "debug": "3.1.0",
+            "globals": "10.4.0",
+            "invariant": "2.2.4",
+            "lodash": "4.17.10"
           }
         },
         "@babel/types": {
@@ -442,9 +350,9 @@
           "integrity": "sha512-y9XT11CozHDgjWcTdxmhSj13rJVXpa5ZXwjjOiTedjaM0ba5ItqdS02t31EhPl7HtOWxsZkYCCUNrSfrOisA6w==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.2.0",
-            "to-fast-properties": "^2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "2.0.0"
           }
         },
         "babylon": {
@@ -462,168 +370,168 @@
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.49.tgz",
-      "integrity": "sha1-l6QeJ4mpv4psMFNqJYt550RMXYI=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.54.tgz",
+      "integrity": "sha1-X3YKGViam28H6Apl70vL1PuowlM=",
       "dev": true,
       "requires": {
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
-        "lodash": "^4.17.5"
+        "@babel/template": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54",
+        "lodash": "4.17.10"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.49.tgz",
-      "integrity": "sha1-QNeO2glo0BGxxShm5XRs+yPldUg=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.54.tgz",
+      "integrity": "sha1-ic2IM8lUgaCCesahv8zduSt1oQk=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/types": "7.0.0-beta.54"
       }
     },
     "@babel/helper-wrap-function": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.49.tgz",
-      "integrity": "sha1-OFWRRgtNk++W7jgZU5wM3Ju9R1g=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.54.tgz",
+      "integrity": "sha1-3Bt6SDowdKNTGzZSPgMVbZEKOio=",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/helper-function-name": "7.0.0-beta.54",
+        "@babel/template": "7.0.0-beta.54",
+        "@babel/traverse": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54"
       }
     },
     "@babel/helpers": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.49.tgz",
-      "integrity": "sha1-BU2EAy1OlChqgFhlAAaOQQBaUdA=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.54.tgz",
+      "integrity": "sha1-uGqZqA79gWaMrvMHYQuWEZdEanQ=",
       "dev": true,
       "requires": {
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/template": "7.0.0-beta.54",
+        "@babel/traverse": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz",
-      "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.54.tgz",
+      "integrity": "sha1-FV1Qc1gym45waJcAF8P9dKmwhYQ=",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
+        "chalk": "2.4.1",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       }
     },
     "@babel/parser": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.49.tgz",
-      "integrity": "sha1-lE0MW6KBK7FZ7b0iZ0Ov0mUXm9w=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.54.tgz",
+      "integrity": "sha1-wBqmO1fJyNzodEeWyB2d8SHyDbQ=",
       "dev": true
     },
     "@babel/plugin-external-helpers": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.0.0-beta.49.tgz",
-      "integrity": "sha1-xn/6niPXBjgQsNQwSFe/XBb4o1s=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.0.0-beta.54.tgz",
+      "integrity": "sha1-FLHq6aW0kayth45fu6Wage06xM4=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.49.tgz",
-      "integrity": "sha1-h2Gl4ti1JR5w3yj00KpkqiillrE=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.54.tgz",
+      "integrity": "sha1-GYcb1lW110iwrj6ezr4ke+i3+Ds=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.49",
-        "@babel/plugin-syntax-async-generators": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.54",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.49.tgz",
-      "integrity": "sha1-bQzWD3p718REo3HE6UcL/wL1d3w=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.54.tgz",
+      "integrity": "sha1-VIEmmgIN0NOHFagJT+0BXTDvTCo=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-syntax-async-generators": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.49.tgz",
-      "integrity": "sha1-UO6UMAKu3JqzqNEikr013Z7bHfg=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.54.tgz",
+      "integrity": "sha1-/6yPZJJ2FHYol8yWQ0lf04CX3UE=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.49.tgz",
-      "integrity": "sha1-8K96xrU2dqSWCT1KbiouxlXAe3g=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.54.tgz",
+      "integrity": "sha1-yWJif04aFdptCEIwbUIeex5S9Yc=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-syntax-import-meta": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.0.0-beta.49.tgz",
-      "integrity": "sha1-x6zIpTZlgxP2JPT1lc8JFHrIQmw=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.0.0-beta.54.tgz",
+      "integrity": "sha1-PFTQeq/glxQwO5laxK1rELD9vDA=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.49.tgz",
-      "integrity": "sha1-R4SziAgj/xLnQsJrQemFf3AdY54=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.54.tgz",
+      "integrity": "sha1-4PRFYSCBq1c+JTWturx7cQ0XlAw=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.49.tgz",
-      "integrity": "sha1-3ThFtjxoPRh9UYbuDogsQEbE8OM=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.54.tgz",
+      "integrity": "sha1-RKl3uOYeTvzHZYu74mDyBMobz3I=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.49.tgz",
-      "integrity": "sha1-kRpA65MEAYbOtpMQXKdt73/pfQM=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.54.tgz",
+      "integrity": "sha1-0DXmXFCISTfWTb5o0WSYwDL4u+w=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.49"
+        "@babel/helper-module-imports": "7.0.0-beta.54",
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.49.tgz",
-      "integrity": "sha1-eqn0b9+HO3IRqqLrDTfEw3Ghq9I=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.54.tgz",
+      "integrity": "sha1-k4p3+xLw4RZhvfU4bkrspH8MBTs=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.49.tgz",
-      "integrity": "sha1-3Vqd3ZhndciyDPW2EGWvs92eqsk=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.54.tgz",
+      "integrity": "sha1-vK4cL/rkzDt7PlRV8KmNrswJo8Y=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "lodash": "^4.17.5"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "lodash": "4.17.10"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -645,9 +553,9 @@
           "integrity": "sha512-l0SE8cl9DUIY4hYAFAKTLX3F2Yr14Qri7uTsuI7iegB5E4KyQy4XY72L3VOxmj6kwR/RDQURoKYr2NzyETGo7A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
+            "chalk": "2.4.1",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
           }
         },
         "@babel/helper-annotate-as-pure": {
@@ -688,7 +596,7 @@
             "@babel/code-frame": "7.0.0-beta.35",
             "@babel/types": "7.0.0-beta.35",
             "babylon": "7.0.0-beta.35",
-            "lodash": "^4.2.0"
+            "lodash": "4.17.10"
           }
         },
         "@babel/types": {
@@ -697,9 +605,9 @@
           "integrity": "sha512-y9XT11CozHDgjWcTdxmhSj13rJVXpa5ZXwjjOiTedjaM0ba5ItqdS02t31EhPl7HtOWxsZkYCCUNrSfrOisA6w==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.2.0",
-            "to-fast-properties": "^2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "2.0.0"
           }
         },
         "babylon": {
@@ -711,245 +619,244 @@
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.49.tgz",
-      "integrity": "sha1-uCWdF0vwerS1ZWZWK0buZSDD39I=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.54.tgz",
+      "integrity": "sha1-soSUlCuU+4bQGZR2PStcQ73Zhq8=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.49.tgz",
-      "integrity": "sha1-Q2Y5LJyC0SMQVsHQApQ4pg02K4I=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.54.tgz",
+      "integrity": "sha1-gfZJo+T8tiwrKtSX94OoALmURy8=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.49.tgz",
-      "integrity": "sha1-+sJEgJ3ey/CV43VVjMtxbaEEIxY=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.54.tgz",
+      "integrity": "sha1-S49Ps0mQKoAGeRkfWdD6U/yklAA=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.49.tgz",
-      "integrity": "sha1-RXstCQBHlGhKpuGwQBUIC4CgihQ=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.54.tgz",
+      "integrity": "sha1-EBcJY2b7Q+vKjtjY0M3R69ZP67I=",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.54",
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.49.tgz",
-      "integrity": "sha1-PscnJr8diaDU1RG+epVJBm9Xqt4=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.54.tgz",
+      "integrity": "sha1-Jh0pkgWKngkjS5/2eCAFT/xV95w=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.49.tgz",
-      "integrity": "sha1-rzn2Dnrvzpsl60rc7dBNUIZs4hg=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.54.tgz",
+      "integrity": "sha1-zHIvmXOTEzfe89HmxVE4WB7dNx4=",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-function-name": "7.0.0-beta.54",
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-instanceof": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.0.0-beta.49.tgz",
-      "integrity": "sha1-4yX5x3Gx+fsm35U9d4AhC7WHq/g=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.0.0-beta.54.tgz",
+      "integrity": "sha1-Hshf3Cxgw+NgLSGzcV25JM9d5cU=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.49.tgz",
-      "integrity": "sha1-B8g4JU1l5oZ+hlE+sPItXyawpWo=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.54.tgz",
+      "integrity": "sha1-cPB+zC87e8n1QqV46C7sGKVQQJg=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.49.tgz",
-      "integrity": "sha1-FtB0gJVLBBXqcPHsPtvQWXvT3f4=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.54.tgz",
+      "integrity": "sha1-+1B0B0FCC7SF7hMV0uETPbTkM9I=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-module-transforms": "7.0.0-beta.54",
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.49.tgz",
-      "integrity": "sha1-swL1VwKEc0PBD/T7hDXMNXR1X+M=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.54.tgz",
+      "integrity": "sha1-0l+tZu/5DeA+5i+DhPCvV7zQZdk=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/helper-replace-supers": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/helper-replace-supers": "7.0.0-beta.54"
       },
       "dependencies": {
         "@babel/helper-optimise-call-expression": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.49.tgz",
-          "integrity": "sha1-qYtDw6bFS+9I+HsQ3EVo3sC0G/c=",
+          "version": "7.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.54.tgz",
+          "integrity": "sha1-SvjdT/kNvSmzvPhf/0OVLirhAW4=",
           "dev": true,
           "requires": {
-            "@babel/types": "7.0.0-beta.49"
+            "@babel/types": "7.0.0-beta.54"
           }
         },
         "@babel/helper-replace-supers": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.49.tgz",
-          "integrity": "sha1-50RMcYBX9qCjZFyvjnj7VG/7DZ8=",
+          "version": "7.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.54.tgz",
+          "integrity": "sha1-kB9aFJOkEHmf06s+DA0p0YBxyJ8=",
           "dev": true,
           "requires": {
-            "@babel/helper-member-expression-to-functions": "7.0.0-beta.49",
-            "@babel/helper-optimise-call-expression": "7.0.0-beta.49",
-            "@babel/traverse": "7.0.0-beta.49",
-            "@babel/types": "7.0.0-beta.49"
+            "@babel/helper-member-expression-to-functions": "7.0.0-beta.54",
+            "@babel/helper-optimise-call-expression": "7.0.0-beta.54",
+            "@babel/traverse": "7.0.0-beta.54",
+            "@babel/types": "7.0.0-beta.54"
           }
         }
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.49.tgz",
-      "integrity": "sha1-HK1xoqMygeXvuxpGI6lkwHPOmi0=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.54.tgz",
+      "integrity": "sha1-djBvGbmsrGzxNyGvFey584KGT/c=",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "7.0.0-beta.49",
-        "@babel/helper-get-function-arity": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-call-delegate": "7.0.0-beta.54",
+        "@babel/helper-get-function-arity": "7.0.0-beta.54",
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.49.tgz",
-      "integrity": "sha1-1O15ZwM/T1tJNjwgNQOJm4NXyuI=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.54.tgz",
+      "integrity": "sha1-i0bhkvO/4Ja7v4bid2TnZi5fmg8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.12.3"
+        "regenerator-transform": "0.13.3"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.49.tgz",
-      "integrity": "sha1-SfE0295PZVg0whUk6eYaWNTheQA=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.54.tgz",
+      "integrity": "sha1-UOc8KvxYmLEFVRDd9g7hOmMBUX8=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.49.tgz",
-      "integrity": "sha1-arqwX8DMqCmq+eKoUES3l2Pmgco=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.54.tgz",
+      "integrity": "sha1-TwhS3w9LHbJCbED6zY/l8Cij28k=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.49.tgz",
-      "integrity": "sha1-CMxbZM9qWUKoe92bSkgY1MuhLfM=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.54.tgz",
+      "integrity": "sha1-Vo8161EYrpb62C6sNjdNeSO0eIM=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/helper-regex": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/helper-regex": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.49.tgz",
-      "integrity": "sha1-5gmu1rj8x+HrzKzyITimRyApQKI=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.54.tgz",
+      "integrity": "sha1-yx9jA8r7hEKmxsaaDfu2BpnzJ7w=",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.49",
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.54",
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.49.tgz",
-      "integrity": "sha1-NlFBujVb9znu/Wwrud8cO3FG5FA=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.54.tgz",
+      "integrity": "sha1-bQaGhiOcnrr1NNHA2AMpU/e1Ibw=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.49.tgz",
-      "integrity": "sha1-w3XbVwl1diFSPUGstiqavw1DdLg=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.54.tgz",
+      "integrity": "sha1-HcfpFQs5qusZ/KHIY+CC9glq/GA=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.49",
-        "@babel/helper-regex": "7.0.0-beta.49",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-plugin-utils": "7.0.0-beta.54",
+        "@babel/helper-regex": "7.0.0-beta.54",
+        "regexpu-core": "4.2.0"
       }
     },
     "@babel/template": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.49.tgz",
-      "integrity": "sha1-44q+ghfLl5P0YaUwbXrXRdg+HSc=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.54.tgz",
+      "integrity": "sha1-1bDS0tVcDniwSMYaBY82z9fZGvM=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.49",
-        "@babel/parser": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
-        "lodash": "^4.17.5"
+        "@babel/code-frame": "7.0.0-beta.54",
+        "@babel/parser": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54",
+        "lodash": "4.17.10"
       }
     },
     "@babel/traverse": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.49.tgz",
-      "integrity": "sha1-TypzaCoYM07WYl0QCo0nMZ98LWg=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.54.tgz",
+      "integrity": "sha1-LBf5jc2/GaqRj94Sjw4aC8CJ4Fo=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.49",
-        "@babel/generator": "7.0.0-beta.49",
-        "@babel/helper-function-name": "7.0.0-beta.49",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.49",
-        "@babel/parser": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
-        "debug": "^3.1.0",
-        "globals": "^11.1.0",
-        "invariant": "^2.2.0",
-        "lodash": "^4.17.5"
+        "@babel/code-frame": "7.0.0-beta.54",
+        "@babel/generator": "7.0.0-beta.54",
+        "@babel/helper-function-name": "7.0.0-beta.54",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.54",
+        "@babel/parser": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54",
+        "debug": "3.1.0",
+        "globals": "11.7.0",
+        "lodash": "4.17.10"
       }
     },
     "@babel/types": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.49.tgz",
-      "integrity": "sha1-t+Oxw/TUz+Eb34yJ8e/V4WF7h6Y=",
+      "version": "7.0.0-beta.54",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.54.tgz",
+      "integrity": "sha1-AlrWhJL+1ULBPxTFeaRMhI5TEGM=",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.5",
-        "to-fast-properties": "^2.0.0"
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "2.0.0"
       }
     },
     "@polymer/esm-amd-loader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.0.tgz",
-      "integrity": "sha512-8ZDZzuu2jkg2A6hC7NeH2GqAwxpS9ADI2PYOGi/n06h6ouyoQK2cWTarUPiCAwmHLvVVQ1ySJsags37H33caZQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.2.tgz",
+      "integrity": "sha512-n45zYqDfZUKBiM+Nj0jU6An2xEP5avKKdsl8ecgh2PbA0I0lamEExs0BmHfD4Br+lJDNbbDEVsUMDlrqNqcceg==",
       "dev": true
     },
     "@polymer/polymer": {
@@ -958,7 +865,7 @@
       "integrity": "sha512-ow8AAjTe9ps8bantY9IvL0PT+xHf5VN3Cjahfr7gBJAc0lv3jTwGBv7pso65SHyrUJEEHeakhx6iPMl7qY4tfw==",
       "dev": true,
       "requires": {
-        "@webcomponents/shadycss": "^1.2.0"
+        "@webcomponents/shadycss": "1.3.5"
       }
     },
     "@polymer/sinonjs": {
@@ -968,9 +875,9 @@
       "dev": true
     },
     "@polymer/test-fixture": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
-      "integrity": "sha1-REN1JpfU2Sk7vEEuoLXk00HxSdk=",
+      "version": "3.0.0-pre.21",
+      "resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-3.0.0-pre.21.tgz",
+      "integrity": "sha512-IxzUe6YzaORzUksafHAXHprV29YncOJgr0+1zNAifl0/f+cb5iAd4IWUrnsnVFHG5UGTLjvis5RgV6vvIZPDrA==",
       "dev": true
     },
     "@types/acorn": {
@@ -979,25 +886,25 @@
       "integrity": "sha512-gou/kWQkGPMZjdCKNZGDpqxLm9+ErG/pFZKPX4tvCjr0Xf4FCYYX3nAsu7aDVKJV3KUe27+mvqqyWT/9VZoM/A==",
       "dev": true,
       "requires": {
-        "@types/estree": "*"
+        "@types/estree": "0.0.39"
       }
     },
     "@types/babel-generator": {
-      "version": "6.25.1",
-      "resolved": "https://registry.npmjs.org/@types/babel-generator/-/babel-generator-6.25.1.tgz",
-      "integrity": "sha512-nKNz9Ch4WP2TFZjQROhxqqS2SCk0OoDzGazJI6S+2sGgW9P7N4o3vluZAXFuPEnRqtz2A0vrrkK3tjQktxIlRw==",
+      "version": "6.25.2",
+      "resolved": "https://registry.npmjs.org/@types/babel-generator/-/babel-generator-6.25.2.tgz",
+      "integrity": "sha512-W7PQkeDlYOqJblfNeqZARwj4W8nO+ZhQQZksU8+wbaKuHeUdIVUAdREO/Qb0FfNr3CY5Sq1gNtqsyFeZfS3iSw==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "*"
+        "@types/babel-types": "6.25.2"
       }
     },
     "@types/babel-traverse": {
-      "version": "6.25.3",
-      "resolved": "https://registry.npmjs.org/@types/babel-traverse/-/babel-traverse-6.25.3.tgz",
-      "integrity": "sha512-4FaulWyA7nrXPkzoukL2VmSpxCnBZwc+MgwZqO30gtHCrtaUXnoxymdYfxzf3CZN80zjtrVzKfLlZ7FPYvrhQQ==",
+      "version": "6.25.4",
+      "resolved": "https://registry.npmjs.org/@types/babel-traverse/-/babel-traverse-6.25.4.tgz",
+      "integrity": "sha512-+/670NaZE7qPvdh8EtGds32/2uHFKE5JeS+7ePH6nGwF8Wj8r671/RkTiJQP2k22nFntWEb9xQ11MFj7xEqI0g==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "*"
+        "@types/babel-types": "6.25.2"
       }
     },
     "@types/babel-types": {
@@ -1007,18 +914,18 @@
       "dev": true
     },
     "@types/babylon": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.2.tgz",
-      "integrity": "sha512-+Jty46mPaWe1VAyZbfvgJM4BAdklLWxrT5tc/RjvCgLrtk6gzRY6AOnoWFv4p6hVxhJshDdr2hGVn56alBp97Q==",
+      "version": "6.16.3",
+      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.3.tgz",
+      "integrity": "sha512-lyJ8sW1PbY3uwuvpOBZ9zMYKshMnQpXmeDHh8dj9j2nJm/xrW0FgB5gLSYOArj5X0IfaXnmhFoJnhS4KbqIMug==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "*"
+        "@types/babel-types": "6.25.2"
       }
     },
     "@types/bluebird": {
-      "version": "3.5.20",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.20.tgz",
-      "integrity": "sha512-Wk41MVdF+cHBfVXj/ufUHJeO3BlIQr1McbHZANErMykaCWeDSZbH5erGjNBw2/3UlRdSxZbLfSuQTzFmPOYFsA==",
+      "version": "3.5.23",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.23.tgz",
+      "integrity": "sha512-xlehmc6RT+wMEhy9ZqeqmozVmuFzTfsaV2NlfFFWhigy7n6sjMbUUB+SZBWK78lZgWHA4DBAdQvQxUvcB8N1tw==",
       "dev": true
     },
     "@types/body-parser": {
@@ -1027,14 +934,14 @@
       "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
       "dev": true,
       "requires": {
-        "@types/connect": "*",
-        "@types/node": "*"
+        "@types/connect": "3.4.32",
+        "@types/node": "9.6.23"
       }
     },
     "@types/chai": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.3.tgz",
-      "integrity": "sha512-f5dXGzOJycyzSMdaXVhiBhauL4dYydXwVpavfQ1mVCaGjR56a9QfklXObUxlIY9bGTmCPHEEZ04I16BZ/8w5ww==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.4.tgz",
+      "integrity": "sha512-h6+VEw2Vr3ORiFCyyJmcho2zALnUq9cvdB/IO8Xs9itrJVCenC7o26A6+m7D0ihTTr65eS259H5/Ghl/VjYs6g==",
       "dev": true
     },
     "@types/chai-subset": {
@@ -1043,7 +950,7 @@
       "integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
       "dev": true,
       "requires": {
-        "@types/chai": "*"
+        "@types/chai": "4.1.4"
       }
     },
     "@types/chalk": {
@@ -1070,7 +977,7 @@
       "integrity": "sha1-ldxzOiM5qoRjgdfxN3eS0lU9wn0=",
       "dev": true,
       "requires": {
-        "@types/express": "*"
+        "@types/express": "4.16.0"
       }
     },
     "@types/connect": {
@@ -1079,7 +986,7 @@
       "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "9.6.23"
       }
     },
     "@types/content-type": {
@@ -1124,9 +1031,9 @@
       "integrity": "sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==",
       "dev": true,
       "requires": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/serve-static": "*"
+        "@types/body-parser": "1.17.0",
+        "@types/express-serve-static-core": "4.16.0",
+        "@types/serve-static": "1.13.2"
       }
     },
     "@types/express-serve-static-core": {
@@ -1135,9 +1042,9 @@
       "integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
-        "@types/node": "*",
-        "@types/range-parser": "*"
+        "@types/events": "1.2.0",
+        "@types/node": "9.6.23",
+        "@types/range-parser": "1.2.2"
       }
     },
     "@types/freeport": {
@@ -1153,9 +1060,9 @@
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
-        "@types/minimatch": "*",
-        "@types/node": "*"
+        "@types/events": "1.2.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "9.6.23"
       }
     },
     "@types/glob-stream": {
@@ -1164,8 +1071,8 @@
       "integrity": "sha512-RHv6ZQjcTncXo3thYZrsbAVwoy4vSKosSWhuhuQxLOTv74OJuFQxXkmUuZCr3q9uNBEVCvIzmZL/FeRNbHZGUg==",
       "dev": true,
       "requires": {
-        "@types/glob": "*",
-        "@types/node": "*"
+        "@types/glob": "5.0.35",
+        "@types/node": "9.6.23"
       }
     },
     "@types/gulp-if": {
@@ -1174,8 +1081,8 @@
       "integrity": "sha512-J5lzff21X7r1x/4hSzn02GgIUEyjCqYIXZ9GgGBLhbsD3RiBdqwnkFWgF16/0jO5rcVZ52Zp+6MQMQdvIsWuKg==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "@types/vinyl": "*"
+        "@types/node": "9.6.23",
+        "@types/vinyl": "2.0.2"
       }
     },
     "@types/html-minifier": {
@@ -1184,9 +1091,9 @@
       "integrity": "sha512-yikK28/KlVyf8g9i/k+TDFlteLuZ6QQTUdVqvKtzEB+8DSLCTjxfh6IK45KnW4rYFI3Y8T4LWpYJMTmfJleWaQ==",
       "dev": true,
       "requires": {
-        "@types/clean-css": "*",
-        "@types/relateurl": "*",
-        "@types/uglify-js": "*"
+        "@types/clean-css": "3.4.30",
+        "@types/relateurl": "0.2.28",
+        "@types/uglify-js": "3.0.3"
       }
     },
     "@types/is-windows": {
@@ -1203,9 +1110,9 @@
       "optional": true
     },
     "@types/mime": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-0.0.29.tgz",
-      "integrity": "sha1-+8/TMFc7kS71nu7hRgK/rOYwdUs=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
+      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
       "dev": true
     },
     "@types/minimatch": {
@@ -1220,14 +1127,14 @@
       "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
       "dev": true,
       "requires": {
-        "@types/bluebird": "*",
-        "@types/node": "*"
+        "@types/bluebird": "3.5.23",
+        "@types/node": "9.6.23"
       }
     },
     "@types/node": {
-      "version": "9.6.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.20.tgz",
-      "integrity": "sha512-mIMXUbH2MmJAQQjzFUIRpxa+FtA27IaHMrIgoJ1fyu/EfpVN/UZw3ISMNnwVec4lau8R8SM4pNFXSCZpJFX2Bw==",
+      "version": "9.6.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.23.tgz",
+      "integrity": "sha512-d2SJJpwkiPudEQ3+9ysANN2Nvz4QJKUPoe/WL5zyQzI0RaEeZWH5K5xjvUIGszTItHQpFPdH+u51f6G/LkS8Cg==",
       "dev": true
     },
     "@types/opn": {
@@ -1236,7 +1143,7 @@
       "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "9.6.23"
       }
     },
     "@types/parse5": {
@@ -1245,7 +1152,7 @@
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "9.6.23"
       }
     },
     "@types/path-is-inside": {
@@ -1278,7 +1185,7 @@
       "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "9.6.23"
       }
     },
     "@types/serve-static": {
@@ -1287,8 +1194,8 @@
       "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
+        "@types/express-serve-static-core": "4.16.0",
+        "@types/mime": "2.0.0"
       }
     },
     "@types/spdy": {
@@ -1297,7 +1204,7 @@
       "integrity": "sha512-N9LBlbVRRYq6HgYpPkqQc3a9HJ/iEtVZToW6xlTtJiMhmRJ7jJdV7TaZQJw/Ve/1ePUsQiCTDc4JMuzzag94GA==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "9.6.23"
       }
     },
     "@types/ua-parser-js": {
@@ -1307,12 +1214,12 @@
       "dev": true
     },
     "@types/uglify-js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.2.tgz",
-      "integrity": "sha512-o8hU2+4xsyGC27Vujoklvxl88Ew5zmJuTBYMX1Uro2rYUt4HEFJKL6fuq8aGykvS+ssIsIzerWWP2DRxonownQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.3.tgz",
+      "integrity": "sha512-MAT0BW2ruO0LhQKjvlipLGCF/Yx0y/cj+tT67tK3QIQDrM2+9R78HgJ54VlrE8AbfjYJJBCQCEPM5ZblPVTuww==",
       "dev": true,
       "requires": {
-        "source-map": "^0.6.1"
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -1329,7 +1236,7 @@
       "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "9.6.23"
       }
     },
     "@types/vinyl": {
@@ -1338,7 +1245,7 @@
       "integrity": "sha512-2iYpNuOl98SrLPBZfEN9Mh2JCJ2EI9HU35SfgBEb51DcmaHkhp8cKMblYeBqMQiwXMgAD3W60DbQ4i/UdLiXhw==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "9.6.23"
       }
     },
     "@types/vinyl-fs": {
@@ -1347,9 +1254,9 @@
       "integrity": "sha512-yE2pN9OOrxJVeO7IZLHAHrh5R4Q0osbn5WQRuQU6GdXoK7dNFrMK3K7YhATkzf3z0yQBkol3+gafs7Rp0s7dDg==",
       "dev": true,
       "requires": {
-        "@types/glob-stream": "*",
-        "@types/node": "*",
-        "@types/vinyl": "*"
+        "@types/glob-stream": "6.1.0",
+        "@types/node": "9.6.23",
+        "@types/vinyl": "2.0.2"
       }
     },
     "@types/whatwg-url": {
@@ -1358,7 +1265,7 @@
       "integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "9.6.23"
       }
     },
     "@types/which": {
@@ -1374,19 +1281,19 @@
       "integrity": "sha512-zzruYOEtNgfS3SBjcij1F6HlH6My5n8WrBNhP3fzaRM22ba70QBC2ATs18jGr88Fy43c0z8vFJv5wJankfxv2A==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "9.6.23"
       }
     },
     "@webcomponents/shadycss": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.2.1.tgz",
-      "integrity": "sha512-ZnjFb1Wf81CqMgs1dbT6JT6N4nY32bs2r5YC/5GSIb/ozJGR+UYs3ldJxtk1v5uZzPRIsAWv7wYSJcCp6ml8+A==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.3.5.tgz",
+      "integrity": "sha512-SBGmmpylJaNbWBQ84BvHl0keEhqOgPVG1zCdxtoQXrp3fUxFbjiJPHjvx6oqMjFTzkmKOwo/oKNvZyEtxltKiA==",
       "dev": true
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.2.0.tgz",
-      "integrity": "sha512-P9JWydfpBR+CK12UwtBaoD/lYF3PR9XBArAWk5J9nfPaJwA3OUox4StZmyFSVDLsvpFq5HsEtxU/OdHAlAWPnw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.0.3.tgz",
+      "integrity": "sha512-MAXeE34PaC2gDVNKa+YLkRvnIBezIslR8AHoS/E8nOYuFL0qUcOD4L7/BBZOrNtxMRrNTCvtkXL7TrEmYmyQiQ==",
       "dev": true
     },
     "accepts": {
@@ -1395,7 +1302,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.19",
         "negotiator": "0.6.1"
       }
     },
@@ -1406,9 +1313,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
       "dev": true
     },
     "acorn-import-meta": {
@@ -1417,24 +1324,16 @@
       "integrity": "sha512-+KB5Q0P0Q/XpsPHgnLx4XbCGqMogw4yiJJjYsbzPCNrE/IoX+c6J4C+BFcwdWh3CD1zLzMxPITN1jzHd+NiS3w==",
       "dev": true,
       "requires": {
-        "acorn": "^5.4.1"
+        "acorn": "5.7.1"
       }
     },
     "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
+      "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
       "dev": true,
       "requires": {
-        "acorn": "^3.0.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
+        "acorn": "5.7.1"
       }
     },
     "adm-zip": {
@@ -1451,41 +1350,31 @@
       "dev": true
     },
     "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "extend": "~3.0.0",
-        "semver": "~5.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-          "dev": true,
-          "optional": true
-        }
+        "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+      "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "ajv-keywords": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
       "dev": true
     },
     "ansi-align": {
@@ -1494,16 +1383,7 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
-        "string-width": "^2.0.0"
-      }
-    },
-    "ansi-escape-sequences": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz",
-      "integrity": "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=",
-      "dev": true,
-      "requires": {
-        "array-back": "^1.0.3"
+        "string-width": "2.1.1"
       }
     },
     "ansi-escapes": {
@@ -1542,14 +1422,25 @@
       "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
       "dev": true,
       "requires": {
-        "archiver-utils": "^1.3.0",
-        "async": "^2.0.0",
-        "buffer-crc32": "^0.2.1",
-        "glob": "^7.0.0",
-        "lodash": "^4.8.0",
-        "readable-stream": "^2.0.0",
-        "tar-stream": "^1.5.0",
-        "zip-stream": "^1.2.0"
+        "archiver-utils": "1.3.0",
+        "async": "2.6.1",
+        "buffer-crc32": "0.2.13",
+        "glob": "7.1.2",
+        "lodash": "4.17.10",
+        "readable-stream": "2.3.6",
+        "tar-stream": "1.6.1",
+        "zip-stream": "1.2.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.10"
+          }
+        }
       }
     },
     "archiver-utils": {
@@ -1558,12 +1449,12 @@
       "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "graceful-fs": "^4.1.0",
-        "lazystream": "^1.0.0",
-        "lodash": "^4.8.0",
-        "normalize-path": "^2.0.0",
-        "readable-stream": "^2.0.0"
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lazystream": "1.0.0",
+        "lodash": "4.17.10",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.6"
       }
     },
     "argparse": {
@@ -1572,7 +1463,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "argv-tools": {
@@ -1581,39 +1472,8 @@
       "integrity": "sha512-Cc0dBvx4dvrjjKpyDA6w8RlNAw8Su30NvZbWl/Tv9ZALEVlLVkWQiHMi84Q0xNfpVuSaiQbYkdmWK8g1PLGhKw==",
       "dev": true,
       "requires": {
-        "array-back": "^2.0.0",
-        "find-replace": "^2.0.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.1"
-          }
-        },
-        "find-replace": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
-          "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
-          "dev": true,
-          "requires": {
-            "array-back": "^2.0.0",
-            "test-value": "^3.0.0"
-          }
-        },
-        "test-value": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
-          "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
-          "dev": true,
-          "requires": {
-            "array-back": "^2.0.0",
-            "typical": "^2.6.1"
-          }
-        }
+        "array-back": "2.0.0",
+        "find-replace": "2.0.1"
       }
     },
     "arr-diff": {
@@ -1635,12 +1495,12 @@
       "dev": true
     },
     "array-back": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-      "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
+      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
       "dev": true,
       "requires": {
-        "typical": "^2.6.0"
+        "typical": "2.6.1"
       }
     },
     "array-find-index": {
@@ -1661,7 +1521,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -1686,12 +1546,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "asn1": {
@@ -1719,21 +1573,10 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.10"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        }
-      }
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
     },
     "async-limiter": {
       "version": "1.0.0",
@@ -1771,9 +1614,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "chalk": {
@@ -1782,11 +1625,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "strip-ansi": {
@@ -1795,7 +1638,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -1806,14 +1649,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -1872,7 +1715,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-minify-builtins": {
@@ -1881,7 +1724,7 @@
       "integrity": "sha1-nqPVn0rEp7uVjXEtKVVqH4b3+B4=",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "^0.4.3"
+        "babel-helper-evaluate-path": "0.4.3"
       }
     },
     "babel-plugin-minify-constant-folding": {
@@ -1890,7 +1733,7 @@
       "integrity": "sha1-MA+d6N2ghEoXaxk2U5YOJK0z4ZE=",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "^0.4.3"
+        "babel-helper-evaluate-path": "0.4.3"
       }
     },
     "babel-plugin-minify-dead-code-elimination": {
@@ -1899,10 +1742,10 @@
       "integrity": "sha1-c2KCZYZPkAjQAnUG9Yq+s8HQLZg=",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "^0.4.3",
-        "babel-helper-mark-eval-scopes": "^0.4.3",
-        "babel-helper-remove-or-void": "^0.4.3",
-        "lodash.some": "^4.6.0"
+        "babel-helper-evaluate-path": "0.4.3",
+        "babel-helper-mark-eval-scopes": "0.4.3",
+        "babel-helper-remove-or-void": "0.4.3",
+        "lodash.some": "4.6.0"
       }
     },
     "babel-plugin-minify-flip-comparisons": {
@@ -1911,7 +1754,7 @@
       "integrity": "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=",
       "dev": true,
       "requires": {
-        "babel-helper-is-void-0": "^0.4.3"
+        "babel-helper-is-void-0": "0.4.3"
       }
     },
     "babel-plugin-minify-guarded-expressions": {
@@ -1920,7 +1763,7 @@
       "integrity": "sha1-ylpZoGvBwi3Vz9mWpnUWOm9hm30=",
       "dev": true,
       "requires": {
-        "babel-helper-flip-expressions": "^0.4.1"
+        "babel-helper-flip-expressions": "0.4.3"
       }
     },
     "babel-plugin-minify-infinity": {
@@ -1935,7 +1778,7 @@
       "integrity": "sha1-FvG/90t6fJPfwkHngx3V+0sCPvc=",
       "dev": true,
       "requires": {
-        "babel-helper-mark-eval-scopes": "^0.4.3"
+        "babel-helper-mark-eval-scopes": "0.4.3"
       }
     },
     "babel-plugin-minify-numeric-literals": {
@@ -1956,9 +1799,9 @@
       "integrity": "sha1-N3VthcYURktLCSfytOQXGR1Vc4o=",
       "dev": true,
       "requires": {
-        "babel-helper-flip-expressions": "^0.4.3",
-        "babel-helper-is-nodes-equiv": "^0.0.1",
-        "babel-helper-to-multiple-sequence-expressions": "^0.4.3"
+        "babel-helper-flip-expressions": "0.4.3",
+        "babel-helper-is-nodes-equiv": "0.0.1",
+        "babel-helper-to-multiple-sequence-expressions": "0.4.3"
       }
     },
     "babel-plugin-minify-type-constructors": {
@@ -1967,7 +1810,7 @@
       "integrity": "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=",
       "dev": true,
       "requires": {
-        "babel-helper-is-void-0": "^0.4.3"
+        "babel-helper-is-void-0": "0.4.3"
       }
     },
     "babel-plugin-transform-inline-consecutive-adds": {
@@ -2000,7 +1843,7 @@
       "integrity": "sha1-NxJ6qgQSXD0Iv5XNtajx0uRMpFM=",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.2"
       }
     },
     "babel-plugin-transform-regexp-constructors": {
@@ -2027,7 +1870,7 @@
       "integrity": "sha1-1AsNp/kcCMBsxyt2dHTAHEiU3gI=",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "^0.4.3"
+        "babel-helper-evaluate-path": "0.4.3"
       }
     },
     "babel-plugin-transform-simplify-comparison-operators": {
@@ -2048,29 +1891,29 @@
       "integrity": "sha1-pQUsWVXdl9JGmbKB/amjAuqMGHE=",
       "dev": true,
       "requires": {
-        "babel-plugin-minify-builtins": "^0.4.0-alpha.caaefb4c",
-        "babel-plugin-minify-constant-folding": "^0.4.0-alpha.caaefb4c",
-        "babel-plugin-minify-dead-code-elimination": "^0.4.0-alpha.caaefb4c",
-        "babel-plugin-minify-flip-comparisons": "^0.4.0-alpha.caaefb4c",
-        "babel-plugin-minify-guarded-expressions": "^0.4.0-alpha.caaefb4c",
-        "babel-plugin-minify-infinity": "^0.4.0-alpha.caaefb4c",
-        "babel-plugin-minify-mangle-names": "^0.4.0-alpha.caaefb4c",
-        "babel-plugin-minify-numeric-literals": "^0.4.0-alpha.caaefb4c",
-        "babel-plugin-minify-replace": "^0.4.0-alpha.caaefb4c",
-        "babel-plugin-minify-simplify": "^0.4.0-alpha.caaefb4c",
-        "babel-plugin-minify-type-constructors": "^0.4.0-alpha.caaefb4c",
-        "babel-plugin-transform-inline-consecutive-adds": "^0.4.0-alpha.caaefb4c",
-        "babel-plugin-transform-member-expression-literals": "^6.10.0-alpha.caaefb4c",
-        "babel-plugin-transform-merge-sibling-variables": "^6.10.0-alpha.caaefb4c",
-        "babel-plugin-transform-minify-booleans": "^6.10.0-alpha.caaefb4c",
-        "babel-plugin-transform-property-literals": "^6.10.0-alpha.caaefb4c",
-        "babel-plugin-transform-regexp-constructors": "^0.4.0-alpha.caaefb4c",
-        "babel-plugin-transform-remove-console": "^6.10.0-alpha.caaefb4c",
-        "babel-plugin-transform-remove-debugger": "^6.10.0-alpha.caaefb4c",
-        "babel-plugin-transform-remove-undefined": "^0.4.0-alpha.caaefb4c",
-        "babel-plugin-transform-simplify-comparison-operators": "^6.10.0-alpha.caaefb4c",
-        "babel-plugin-transform-undefined-to-void": "^6.10.0-alpha.caaefb4c",
-        "lodash.isplainobject": "^4.0.6"
+        "babel-plugin-minify-builtins": "0.4.3",
+        "babel-plugin-minify-constant-folding": "0.4.3",
+        "babel-plugin-minify-dead-code-elimination": "0.4.3",
+        "babel-plugin-minify-flip-comparisons": "0.4.3",
+        "babel-plugin-minify-guarded-expressions": "0.4.1",
+        "babel-plugin-minify-infinity": "0.4.3",
+        "babel-plugin-minify-mangle-names": "0.4.3",
+        "babel-plugin-minify-numeric-literals": "0.4.3",
+        "babel-plugin-minify-replace": "0.4.3",
+        "babel-plugin-minify-simplify": "0.4.3",
+        "babel-plugin-minify-type-constructors": "0.4.3",
+        "babel-plugin-transform-inline-consecutive-adds": "0.4.3",
+        "babel-plugin-transform-member-expression-literals": "6.10.0-alpha.f95869d4",
+        "babel-plugin-transform-merge-sibling-variables": "6.10.0-alpha.f95869d4",
+        "babel-plugin-transform-minify-booleans": "6.10.0-alpha.f95869d4",
+        "babel-plugin-transform-property-literals": "6.10.0-alpha.f95869d4",
+        "babel-plugin-transform-regexp-constructors": "0.4.3",
+        "babel-plugin-transform-remove-console": "6.10.0-alpha.f95869d4",
+        "babel-plugin-transform-remove-debugger": "6.10.0-alpha.f95869d4",
+        "babel-plugin-transform-remove-undefined": "0.4.3",
+        "babel-plugin-transform-simplify-comparison-operators": "6.10.0-alpha.f95869d4",
+        "babel-plugin-transform-undefined-to-void": "6.10.0-alpha.f95869d4",
+        "lodash.isplainobject": "4.0.6"
       }
     },
     "babel-runtime": {
@@ -2079,8 +1922,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "babel-traverse": {
@@ -2089,15 +1932,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "babylon": {
@@ -2129,10 +1972,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "1.0.3"
       },
       "dependencies": {
         "to-fast-properties": {
@@ -2167,13 +2010,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2182,7 +2025,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -2191,7 +2034,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -2200,7 +2043,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -2209,9 +2052,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -2226,8 +2069,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
       "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "base64id": {
       "version": "1.0.0",
@@ -2236,13 +2078,13 @@
       "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "better-assert": {
@@ -2260,8 +2102,8 @@
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "blob": {
@@ -2277,15 +2119,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "debug": {
@@ -2296,15 +2138,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "iconv-lite": {
-          "version": "0.4.23",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
         }
       }
     },
@@ -2314,7 +2147,7 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "bower-config": {
@@ -2323,11 +2156,11 @@
       "integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.3",
-        "mout": "^1.0.0",
-        "optimist": "^0.6.1",
-        "osenv": "^0.1.3",
-        "untildify": "^2.1.0"
+        "graceful-fs": "4.1.11",
+        "mout": "1.1.0",
+        "optimist": "0.6.1",
+        "osenv": "0.1.5",
+        "untildify": "2.1.0"
       }
     },
     "boxen": {
@@ -2336,13 +2169,13 @@
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^2.0.0"
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.4.1",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "2.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -2359,7 +2192,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -2369,16 +2202,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.2",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2387,19 +2220,19 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
     },
     "browser-capabilities": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/browser-capabilities/-/browser-capabilities-1.1.0.tgz",
-      "integrity": "sha512-D0AhTybfR0KbVxy1DShQut4eCeluMyJhbTgVTIxvItJKzEGG9pNvOBFZfpeCASo2z0XdfczuvSfNZe/vmNlqwQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/browser-capabilities/-/browser-capabilities-1.1.1.tgz",
+      "integrity": "sha512-b+zF28HRpaKhdvLGqirkvn8XO+WEpLxAWg+dqa3OAoriVMS2UucVc1xis4Et9vMnQGLSipWks8bDeCeUvuZ0EQ==",
       "dev": true,
       "requires": {
-        "@types/ua-parser-js": "^0.7.31",
-        "ua-parser-js": "^0.7.15"
+        "@types/ua-parser-js": "0.7.32",
+        "ua-parser-js": "0.7.18"
       }
     },
     "browser-stdout": {
@@ -2409,13 +2242,23 @@
       "dev": true
     },
     "browserstack": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.0.tgz",
-      "integrity": "sha1-tWVCWtYu1ywQgqHrl51TE8fUdU8=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.1.tgz",
+      "integrity": "sha512-O8VMT64P9NOLhuIoD4YngyxBURefaSdR4QdhG8l6HZ9VxtU7jc3m6jLufFwKA5gaf7fetfB2TnRJnMxyob+heg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "https-proxy-agent": "1.0.0"
+        "https-proxy-agent": "2.2.1"
+      }
+    },
+    "buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.0.tgz",
+      "integrity": "sha512-nUJyfChH7PMJy75eRDCCKtszSEFokUNXC1hNVSe+o+VdcgvDPLs20k3v8UXI8ruRYAJiYtyRea8mYyqPxoHWDw==",
+      "dev": true,
+      "requires": {
+        "base64-js": "1.2.0",
+        "ieee754": "1.1.12"
       }
     },
     "buffer-alloc": {
@@ -2424,8 +2267,8 @@
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-fill": "1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -2447,9 +2290,9 @@
       "dev": true
     },
     "buffer-from": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
       "dev": true
     },
     "builtin-modules": {
@@ -2465,7 +2308,7 @@
       "dev": true,
       "requires": {
         "dicer": "0.2.5",
-        "readable-stream": "1.1.x"
+        "readable-stream": "1.1.14"
       },
       "dependencies": {
         "isarray": {
@@ -2480,10 +2323,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -2506,15 +2349,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       }
     },
     "caller-path": {
@@ -2523,7 +2366,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "callsites": "0.2.0"
       }
     },
     "callsite": {
@@ -2544,8 +2387,8 @@
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "camelcase": {
@@ -2560,8 +2403,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       }
     },
     "cancel-token": {
@@ -2570,7 +2413,7 @@
       "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
       "dev": true,
       "requires": {
-        "@types/node": "^4.0.30"
+        "@types/node": "4.2.23"
       },
       "dependencies": {
         "@types/node": {
@@ -2594,28 +2437,25 @@
       "dev": true
     },
     "chai": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "check-error": "^1.0.1",
-        "deep-eql": "^3.0.0",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.0.0",
-        "type-detect": "^4.0.0"
+        "assertion-error": "1.1.0",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
       }
     },
     "chalk": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2624,16 +2464,16 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "supports-color": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2674,10 +2514,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -2686,7 +2526,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -2697,7 +2537,7 @@
       "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.x"
+        "source-map": "0.5.7"
       }
     },
     "cleankill": {
@@ -2718,7 +2558,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-width": {
@@ -2751,23 +2591,23 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.1"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
       "dev": true
     },
     "colors": {
@@ -2782,32 +2622,32 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "command-line-args": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.5.tgz",
-      "integrity": "sha1-W9StReeYPlwTRJGOQCgO4mk8WsA=",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.2.tgz",
+      "integrity": "sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==",
       "dev": true,
       "requires": {
-        "array-back": "^1.0.4",
-        "feature-detect-es6": "^1.3.1",
-        "find-replace": "^1.0.2",
-        "typical": "^2.6.0"
+        "argv-tools": "0.1.1",
+        "array-back": "2.0.0",
+        "find-replace": "2.0.1",
+        "lodash.camelcase": "4.3.0",
+        "typical": "2.6.1"
       }
     },
     "command-line-usage": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-3.0.8.tgz",
-      "integrity": "sha1-tqIJeMGzg0d/XBGlKUKLiAv+D00=",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.5.tgz",
+      "integrity": "sha512-d8NrGylA5oCXSbGoKz05FkehDAzSmIm4K03S5VDh4d5lZAtTWfc3D1RuETtuQCn8129nYfJfDdF7P/lwcz1BlA==",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "^3.0.0",
-        "array-back": "^1.0.3",
-        "feature-detect-es6": "^1.3.1",
-        "table-layout": "^0.3.0",
-        "typical": "^2.6.0"
+        "array-back": "2.0.0",
+        "chalk": "2.4.1",
+        "table-layout": "0.4.4",
+        "typical": "2.6.1"
       }
     },
     "commander": {
@@ -2816,7 +2656,7 @@
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
-        "graceful-readlink": ">= 1.0.0"
+        "graceful-readlink": "1.0.1"
       }
     },
     "component-bind": {
@@ -2843,10 +2683,10 @@
       "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "^0.2.1",
-        "crc32-stream": "^2.0.0",
-        "normalize-path": "^2.0.0",
-        "readable-stream": "^2.0.0"
+        "buffer-crc32": "0.2.13",
+        "crc32-stream": "2.0.0",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.6"
       }
     },
     "compressible": {
@@ -2855,30 +2695,22 @@
       "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
       "dev": true,
       "requires": {
-        "mime-db": ">= 1.34.0 < 2"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.34.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.34.0.tgz",
-          "integrity": "sha1-RS0Oz/XDA0am3B5kseruDTcZ/5o=",
-          "dev": true
-        }
+        "mime-db": "1.35.0"
       }
     },
     "compression": {
-      "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
-      "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
+      "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "bytes": "3.0.0",
-        "compressible": "~2.0.13",
+        "compressible": "2.0.14",
         "debug": "2.6.9",
-        "on-headers": "~1.0.1",
-        "safe-buffer": "5.1.1",
-        "vary": "~1.1.2"
+        "on-headers": "1.0.1",
+        "safe-buffer": "5.1.2",
+        "vary": "1.1.2"
       },
       "dependencies": {
         "debug": {
@@ -2904,10 +2736,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "configstore": {
@@ -2916,12 +2748,12 @@
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.3.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "content-disposition": {
@@ -2984,15 +2816,18 @@
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "dev": true,
       "requires": {
-        "crc": "^3.4.4",
-        "readable-stream": "^2.0.0"
+        "crc": "3.8.0",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "crc": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
-          "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ=",
-          "dev": true
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+          "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "5.2.0"
+          }
         }
       }
     },
@@ -3002,18 +2837,20 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "1.0.0"
       }
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "nice-try": "1.0.4",
+        "path-key": "2.0.1",
+        "semver": "5.5.0",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "crypt": {
@@ -3028,7 +2865,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.x.x"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
@@ -3037,7 +2874,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         }
       }
@@ -3054,125 +2891,11 @@
       "integrity": "sha512-cObrY+mhFEmepWpua6EpMrgRNTQ0eeym+kvR0lukI6hDEzK7F8himEDS4cJ9+fPHCoArTzVrrR0d+oAUbTR1NA==",
       "dev": true,
       "requires": {
-        "command-line-args": "^5.0.2",
-        "command-line-usage": "^5.0.5",
-        "dom5": "^3.0.0",
-        "parse5": "^4.0.0",
-        "shady-css-parser": "^0.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.1"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "command-line-args": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.2.tgz",
-          "integrity": "sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==",
-          "dev": true,
-          "requires": {
-            "argv-tools": "^0.1.1",
-            "array-back": "^2.0.0",
-            "find-replace": "^2.0.1",
-            "lodash.camelcase": "^4.3.0",
-            "typical": "^2.6.1"
-          }
-        },
-        "command-line-usage": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.5.tgz",
-          "integrity": "sha512-d8NrGylA5oCXSbGoKz05FkehDAzSmIm4K03S5VDh4d5lZAtTWfc3D1RuETtuQCn8129nYfJfDdF7P/lwcz1BlA==",
-          "dev": true,
-          "requires": {
-            "array-back": "^2.0.0",
-            "chalk": "^2.4.1",
-            "table-layout": "^0.4.3",
-            "typical": "^2.6.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-          "dev": true
-        },
-        "find-replace": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
-          "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
-          "dev": true,
-          "requires": {
-            "array-back": "^2.0.0",
-            "test-value": "^3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "table-layout": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.4.tgz",
-          "integrity": "sha512-uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==",
-          "dev": true,
-          "requires": {
-            "array-back": "^2.0.0",
-            "deep-extend": "~0.6.0",
-            "lodash.padend": "^4.6.1",
-            "typical": "^2.6.1",
-            "wordwrapjs": "^3.0.0"
-          }
-        },
-        "test-value": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
-          "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
-          "dev": true,
-          "requires": {
-            "array-back": "^2.0.0",
-            "typical": "^2.6.1"
-          }
-        },
-        "wordwrapjs": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-          "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
-          "dev": true,
-          "requires": {
-            "reduce-flatten": "^1.0.1",
-            "typical": "^2.6.1"
-          }
-        }
+        "command-line-args": "5.0.2",
+        "command-line-usage": "5.0.5",
+        "dom5": "3.0.1",
+        "parse5": "4.0.0",
+        "shady-css-parser": "0.1.0"
       }
     },
     "cssbeautify": {
@@ -3187,7 +2910,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "cycle": {
@@ -3202,7 +2925,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "debug": {
@@ -3227,18 +2950,26 @@
       "dev": true
     },
     "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
       "requires": {
-        "type-detect": "^4.0.0"
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
       }
     },
     "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "deep-is": {
@@ -3247,14 +2978,24 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.12"
+      }
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -3263,7 +3004,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -3272,7 +3013,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -3281,9 +3022,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -3294,13 +3035,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
       }
     },
     "delayed-stream": {
@@ -3333,7 +3074,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "detect-node": {
@@ -3348,7 +3089,7 @@
       "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.x",
+        "readable-stream": "1.1.14",
         "streamsearch": "0.1.2"
       },
       "dependencies": {
@@ -3364,10 +3105,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -3390,7 +3131,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.2"
       }
     },
     "dom-serializer": {
@@ -3399,8 +3140,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -3417,18 +3158,18 @@
       "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
       "dev": true,
       "requires": {
-        "urijs": "^1.16.1"
+        "urijs": "1.19.1"
       }
     },
     "dom5": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dom5/-/dom5-3.0.0.tgz",
-      "integrity": "sha512-PbE+7C4Sh1dHDTLNuSDaMUGD1ivDiSZw0L+a9xVUzUKeQ8w3vdzfKHRA07CxcrFZZOa1SGl2nIJ9T49j63q+bg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dom5/-/dom5-3.0.1.tgz",
+      "integrity": "sha512-JPFiouQIr16VQ4dX6i0+Hpbg3H2bMKPmZ+WZgBOSSvOPx9QHwwY8sPzeM2baUtViESYto6wC2nuZOMC/6gulcA==",
       "dev": true,
       "requires": {
-        "@types/parse5": "^2.2.32",
-        "clone": "^2.1.0",
-        "parse5": "^4.0.0"
+        "@types/parse5": "2.2.34",
+        "clone": "2.1.1",
+        "parse5": "4.0.0"
       }
     },
     "domelementtype": {
@@ -3443,7 +3184,7 @@
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "dev": true,
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "domutils": {
@@ -3452,8 +3193,8 @@
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "dev": true,
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
       }
     },
     "dot-prop": {
@@ -3462,7 +3203,7 @@
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "duplexer2": {
@@ -3471,7 +3212,7 @@
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.6"
       }
     },
     "duplexer3": {
@@ -3486,10 +3227,10 @@
       "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -3499,7 +3240,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "ee-first": {
@@ -3526,7 +3267,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "engine.io": {
@@ -3535,12 +3276,12 @@
       "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "ws": "~3.3.1"
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
+        "ws": "3.3.3"
       }
     },
     "engine.io-client": {
@@ -3551,14 +3292,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "ws": "3.3.3",
+        "xmlhttprequest-ssl": "1.5.5",
         "yeast": "0.1.2"
       }
     },
@@ -3569,10 +3310,10 @@
       "dev": true,
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
+        "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "~1.0.2"
+        "has-binary2": "1.0.3"
       }
     },
     "entities": {
@@ -3582,12 +3323,36 @@
       "dev": true
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.4",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.4",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "es6-promise": {
@@ -3603,7 +3368,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "es6-promise": "^4.0.3"
+        "es6-promise": "4.2.4"
       }
     },
     "escape-html": {
@@ -3619,69 +3384,76 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.2.0.tgz",
+      "integrity": "sha512-zlggW1qp7/TBjwLfouRoY7eWXrXwJZFqCdIxxh0/LVB/QuuKuIMkzyUZEcDo6LBadsry5JcEMxIqd3H/66CXVg==",
       "dev": true,
       "requires": {
-        "ajv": "^5.3.0",
-        "babel-code-frame": "^6.22.0",
-        "chalk": "^2.1.0",
-        "concat-stream": "^1.6.0",
-        "cross-spawn": "^5.1.0",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^3.7.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^3.5.4",
-        "esquery": "^1.0.0",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.0.1",
-        "ignore": "^3.3.3",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^3.0.6",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.9.1",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.2",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
-        "progress": "^2.0.0",
-        "regexpp": "^1.0.1",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.3.0",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "~2.0.1",
-        "table": "4.0.2",
-        "text-table": "~0.2.0"
+        "ajv": "6.5.2",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.4.1",
+        "cross-spawn": "6.0.5",
+        "debug": "3.1.0",
+        "doctrine": "2.1.0",
+        "eslint-scope": "4.0.0",
+        "eslint-utils": "1.3.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "4.0.0",
+        "esquery": "1.0.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "11.7.0",
+        "ignore": "4.0.2",
+        "imurmurhash": "0.1.4",
+        "inquirer": "5.2.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.12.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "regexpp": "1.1.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.5.0",
+        "string.prototype.matchall": "2.0.0",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.3",
+        "text-table": "0.2.0"
       }
     },
     "eslint-plugin-html": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-4.0.3.tgz",
-      "integrity": "sha512-ArFnlfQxwYSz/CP0zvk8Cy3MUhcDpT3o6jgO8eKD/b8ezcLVBrgkYzmMv+7S/ya+Yl9pN+Cz2tsgYp/zElkQzA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-4.0.5.tgz",
+      "integrity": "sha512-yULqYldzhYXTwZEaJXM30HhfgJdtTzuVH3LeoANybESHZ5+2ztLD72BsB2wR124/kk/PvQqZofDFSdNIk+kykw==",
       "dev": true,
       "requires": {
-        "htmlparser2": "^3.8.2"
+        "htmlparser2": "3.9.2"
       }
     },
     "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -3690,28 +3462,28 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
+      "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
       "dev": true,
       "requires": {
-        "acorn": "^5.5.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "5.7.1",
+        "acorn-jsx": "4.1.1"
       }
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esquery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.2.0"
       }
     },
     "esrecurse": {
@@ -3720,7 +3492,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -3753,13 +3525,26 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.3",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
+          }
+        }
       }
     },
     "expand-brackets": {
@@ -3768,13 +3553,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "debug": {
@@ -3792,7 +3577,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -3801,7 +3586,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -3812,7 +3597,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.4"
       },
       "dependencies": {
         "fill-range": {
@@ -3821,11 +3606,11 @@
           "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
           "dev": true,
           "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^3.0.0",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "3.0.0",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
           }
         },
         "is-number": {
@@ -3834,7 +3619,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "isobject": {
@@ -3852,7 +3637,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3863,7 +3648,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "express": {
@@ -3872,36 +3657,36 @@
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.3",
+        "proxy-addr": "2.0.4",
         "qs": "6.5.1",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "body-parser": {
@@ -3911,15 +3696,15 @@
           "dev": true,
           "requires": {
             "bytes": "3.0.0",
-            "content-type": "~1.0.4",
+            "content-type": "1.0.4",
             "debug": "2.6.9",
-            "depd": "~1.1.1",
-            "http-errors": "~1.6.2",
+            "depd": "1.1.2",
+            "http-errors": "1.6.3",
             "iconv-lite": "0.4.19",
-            "on-finished": "~2.3.0",
+            "on-finished": "2.3.0",
             "qs": "6.5.1",
             "raw-body": "2.3.2",
-            "type-is": "~1.6.15"
+            "type-is": "1.6.16"
           }
         },
         "debug": {
@@ -3930,6 +3715,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+          "dev": true
         },
         "qs": {
           "version": "6.5.1",
@@ -3964,7 +3755,7 @@
                 "depd": "1.1.1",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.0.3",
-                "statuses": ">= 1.3.1 < 2"
+                "statuses": "1.4.0"
               }
             },
             "setprototypeof": {
@@ -3975,6 +3766,12 @@
             }
           }
         },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "dev": true
+        },
         "send": {
           "version": "0.16.2",
           "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
@@ -3982,18 +3779,18 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "destroy": "~1.0.4",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "etag": "~1.8.1",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "~1.6.2",
+            "http-errors": "1.6.3",
             "mime": "1.4.1",
             "ms": "2.0.0",
-            "on-finished": "~2.3.0",
-            "range-parser": "~1.2.0",
-            "statuses": "~1.4.0"
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.4.0"
           }
         },
         "statuses": {
@@ -4005,9 +3802,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
     "extend-shallow": {
@@ -4016,8 +3813,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -4026,20 +3823,20 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
     },
     "external-editor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.23",
+        "tmp": "0.0.33"
       }
     },
     "extglob": {
@@ -4048,14 +3845,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -4064,7 +3861,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "extend-shallow": {
@@ -4073,7 +3870,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -4082,7 +3879,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -4091,7 +3888,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -4100,9 +3897,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -4120,9 +3917,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -4144,16 +3941,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "pend": "~1.2.0"
-      }
-    },
-    "feature-detect-es6": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.1.tgz",
-      "integrity": "sha512-iMxKpKdIBgcWiBPtz2qnEsNjCE2dBQvDyUqgrXLJboiaHwJa+2vDIZ8XbgNZGh1Rx1PUfZmI7uhG6Z4iQYWVjg==",
-      "dev": true,
-      "requires": {
-        "array-back": "^1.0.4"
+        "pend": "1.2.0"
       }
     },
     "figures": {
@@ -4162,7 +3950,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -4171,8 +3959,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       }
     },
     "filename-regex": {
@@ -4187,10 +3975,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -4199,7 +3987,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -4211,12 +3999,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -4242,7 +4030,7 @@
       "integrity": "sha1-2whKbL+ZVk2Zhprnn73s9m6KGFw=",
       "dev": true,
       "requires": {
-        "async": "~0.2.9"
+        "async": "0.2.10"
       },
       "dependencies": {
         "async": {
@@ -4254,13 +4042,13 @@
       }
     },
     "find-replace": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-      "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
+      "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
       "dev": true,
       "requires": {
-        "array-back": "^1.0.4",
-        "test-value": "^2.1.0"
+        "array-back": "2.0.0",
+        "test-value": "3.0.0"
       }
     },
     "find-up": {
@@ -4269,8 +4057,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "findup-sync": {
@@ -4279,10 +4067,10 @@
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.10",
+        "resolve-dir": "1.0.1"
       }
     },
     "first-chunk-stream": {
@@ -4297,19 +4085,19 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       }
     },
     "follow-redirects": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
-      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
+      "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0"
+        "debug": "3.1.0"
       }
     },
     "for-in": {
@@ -4324,8 +4112,14 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -4345,18 +4139,18 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.19"
       }
     },
     "formatio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "1.x"
+        "samsam": "1.1.2"
       }
     },
     "forwarded": {
@@ -4371,7 +4165,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "freeport": {
@@ -4397,6 +4191,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "functional-red-black-tree": {
@@ -4435,7 +4235,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
@@ -4444,12 +4244,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -4458,8 +4258,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "is-extglob": {
@@ -4474,7 +4274,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -4485,7 +4285,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "is-extglob": {
@@ -4500,7 +4300,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -4511,14 +4311,14 @@
       "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "glob": "^5.0.3",
-        "glob-parent": "^3.0.0",
-        "micromatch": "^2.3.7",
-        "ordered-read-streams": "^0.3.0",
-        "through2": "^0.6.0",
-        "to-absolute-glob": "^0.1.1",
-        "unique-stream": "^2.0.2"
+        "extend": "3.0.2",
+        "glob": "5.0.15",
+        "glob-parent": "3.1.0",
+        "micromatch": "2.3.11",
+        "ordered-read-streams": "0.3.0",
+        "through2": "0.6.5",
+        "to-absolute-glob": "0.1.1",
+        "unique-stream": "2.2.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -4527,7 +4327,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -4542,9 +4342,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
           }
         },
         "expand-brackets": {
@@ -4553,7 +4353,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -4562,7 +4362,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "glob": {
@@ -4571,11 +4371,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "glob-parent": {
@@ -4584,8 +4384,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           }
         },
         "is-extglob": {
@@ -4606,7 +4406,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -4615,19 +4415,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           },
           "dependencies": {
             "is-glob": {
@@ -4636,7 +4436,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
               }
             }
           }
@@ -4647,10 +4447,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -4665,8 +4465,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -4677,7 +4477,7 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "1.3.5"
       }
     },
     "global-modules": {
@@ -4686,9 +4486,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -4697,17 +4497,17 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.1"
       }
     },
     "globals": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
-      "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+      "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
       "dev": true
     },
     "globby": {
@@ -4716,12 +4516,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "got": {
@@ -4730,17 +4530,17 @@
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
-        "create-error-class": "^3.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.1",
+        "safe-buffer": "5.1.2",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
       }
     },
     "graceful-fs": {
@@ -4767,9 +4567,9 @@
       "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
       "dev": true,
       "requires": {
-        "gulp-match": "^1.0.3",
-        "ternary-stream": "^2.0.1",
-        "through2": "^2.0.1"
+        "gulp-match": "1.0.3",
+        "ternary-stream": "2.0.1",
+        "through2": "2.0.3"
       }
     },
     "gulp-match": {
@@ -4778,7 +4578,7 @@
       "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
       "dev": true,
       "requires": {
-        "minimatch": "^3.0.3"
+        "minimatch": "3.0.4"
       }
     },
     "gulp-sourcemaps": {
@@ -4787,11 +4587,11 @@
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "dev": true,
       "requires": {
-        "convert-source-map": "^1.1.1",
-        "graceful-fs": "^4.1.2",
-        "strip-bom": "^2.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^1.0.0"
+        "convert-source-map": "1.5.1",
+        "graceful-fs": "4.1.11",
+        "strip-bom": "2.0.0",
+        "through2": "2.0.3",
+        "vinyl": "1.2.0"
       }
     },
     "handle-thing": {
@@ -4812,8 +4612,43 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        }
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -4822,7 +4657,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-binary2": {
@@ -4860,15 +4695,21 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "has-values": {
@@ -4877,8 +4718,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -4887,7 +4728,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -4898,10 +4739,10 @@
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
       }
     },
     "he": {
@@ -4922,13 +4763,13 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
     "hpack.js": {
@@ -4937,31 +4778,31 @@
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "obuf": "^1.0.0",
-        "readable-stream": "^2.0.1",
-        "wbuf": "^1.1.0"
+        "inherits": "2.0.3",
+        "obuf": "1.1.2",
+        "readable-stream": "2.3.6",
+        "wbuf": "1.7.3"
       }
     },
     "html-minifier": {
-      "version": "3.5.16",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.16.tgz",
-      "integrity": "sha512-zP5EfLSpiLRp0aAgud4CQXPQZm9kXwWjR/cF0PfdOj+jjWnOaCgeZcll4kYXSvIBPeUMmyaSc7mM4IDtA+kboA==",
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.19.tgz",
+      "integrity": "sha512-Qr2JC9nsjK8oCrEmuB430ZIA8YWbF3D5LSjywD75FTuXmeqacwHgIM8wp3vHYzzPbklSjp53RdmDuzR4ub2HzA==",
       "dev": true,
       "requires": {
-        "camel-case": "3.0.x",
-        "clean-css": "4.1.x",
-        "commander": "2.15.x",
-        "he": "1.1.x",
-        "param-case": "2.1.x",
-        "relateurl": "0.2.x",
-        "uglify-js": "3.3.x"
+        "camel-case": "3.0.0",
+        "clean-css": "4.1.11",
+        "commander": "2.16.0",
+        "he": "1.1.1",
+        "param-case": "2.1.1",
+        "relateurl": "0.2.7",
+        "uglify-js": "3.4.6"
       },
       "dependencies": {
         "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "version": "2.16.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+          "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
           "dev": true
         }
       }
@@ -4972,12 +4813,12 @@
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.0",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.2",
+        "domutils": "1.7.0",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "http-deceiver": {
@@ -4992,10 +4833,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "statuses": "1.5.0"
       }
     },
     "http-proxy": {
@@ -5004,9 +4845,9 @@
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "dev": true,
       "requires": {
-        "eventemitter3": "^3.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
+        "eventemitter3": "3.1.0",
+        "follow-redirects": "1.5.1",
+        "requires-port": "1.0.0"
       }
     },
     "http-proxy-middleware": {
@@ -5015,10 +4856,10 @@
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "dev": true,
       "requires": {
-        "http-proxy": "^1.16.2",
-        "is-glob": "^3.1.0",
-        "lodash": "^4.17.2",
-        "micromatch": "^2.3.11"
+        "http-proxy": "1.17.0",
+        "is-glob": "3.1.0",
+        "lodash": "4.17.10",
+        "micromatch": "2.3.11"
       },
       "dependencies": {
         "arr-diff": {
@@ -5027,7 +4868,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -5042,9 +4883,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
           }
         },
         "expand-brackets": {
@@ -5053,7 +4894,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -5062,7 +4903,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-extglob": {
@@ -5077,7 +4918,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -5086,19 +4927,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           },
           "dependencies": {
             "is-glob": {
@@ -5107,7 +4948,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
               }
             }
           }
@@ -5120,45 +4961,41 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
       }
     },
     "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
+        "agent-base": "4.2.1",
+        "debug": "3.1.0"
       }
     },
     "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "ieee754": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
       "dev": true
     },
     "ignore": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.2.tgz",
+      "integrity": "sha512-uoxnT7PYpyEnsja+yX+7v49B7LXxmzDJ2JALqHH3oEGzpM2U1IGcbfnOr8Dt57z3B/UWs7/iAgPFbmye8m4I0g==",
       "dev": true
     },
     "import-lazy": {
@@ -5185,7 +5022,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "indexof": {
@@ -5200,8 +5037,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -5217,25 +5054,24 @@
       "dev": true
     },
     "inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+      "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.2.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.10",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rxjs": "5.5.11",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
       }
     },
     "invariant": {
@@ -5244,13 +5080,13 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "ipaddr.js": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
-      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -5259,7 +5095,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5268,7 +5104,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -5291,8 +5127,14 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
     },
     "is-ci": {
       "version": "1.1.0",
@@ -5300,7 +5142,7 @@
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "1.1.3"
       }
     },
     "is-data-descriptor": {
@@ -5309,7 +5151,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5318,10 +5160,16 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -5329,9 +5177,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -5354,7 +5202,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -5375,7 +5223,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -5390,7 +5238,7 @@
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "dev": true,
       "requires": {
-        "is-extglob": "^2.1.0"
+        "is-extglob": "2.1.1"
       }
     },
     "is-installed-globally": {
@@ -5399,8 +5247,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.1"
       }
     },
     "is-npm": {
@@ -5415,7 +5263,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5424,7 +5272,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -5434,23 +5282,6 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
-    },
-    "is-odd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-      "dev": true,
-      "requires": {
-        "is-number": "^4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        }
-      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -5464,7 +5295,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -5473,7 +5304,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-object": {
@@ -5482,7 +5313,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -5509,6 +5340,15 @@
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.3"
+      }
+    },
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
@@ -5525,6 +5365,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
     "is-typedarray": {
@@ -5582,13 +5428,13 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "jsbn": {
@@ -5611,9 +5457,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stable-stringify": {
@@ -5622,7 +5468,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -5685,7 +5531,7 @@
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
-        "package-json": "^4.0.0"
+        "package-json": "4.0.1"
       }
     },
     "launchpad": {
@@ -5695,14 +5541,24 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "async": "^2.0.1",
-        "browserstack": "^1.2.0",
-        "debug": "^2.2.0",
-        "plist": "^2.0.1",
-        "q": "^1.4.1",
-        "underscore": "^1.8.3"
+        "async": "2.6.1",
+        "browserstack": "1.5.1",
+        "debug": "2.6.9",
+        "plist": "2.1.0",
+        "q": "1.5.1",
+        "underscore": "1.9.1"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "lodash": "4.17.10"
+          }
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -5728,7 +5584,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "2.3.6"
       }
     },
     "levn": {
@@ -5737,8 +5593,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "load-json-file": {
@@ -5747,17 +5603,17 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       }
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
     "lodash._baseassign": {
@@ -5766,8 +5622,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash.keys": "^3.0.0"
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
       }
     },
     "lodash._basecopy": {
@@ -5812,9 +5668,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "^3.0.0",
-        "lodash._basecreate": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0"
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
       }
     },
     "lodash.defaults": {
@@ -5853,9 +5709,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash.padend": {
@@ -5882,8 +5738,8 @@
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "~3.0.0",
-        "lodash.templatesettings": "^4.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.templatesettings": "4.1.0"
       }
     },
     "lodash.templatesettings": {
@@ -5892,22 +5748,22 @@
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "~3.0.0"
+        "lodash._reinterpolate": "3.0.0"
       }
     },
     "lolex": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "loud-rejection": {
@@ -5916,8 +5772,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lower-case": {
@@ -5933,13 +5789,13 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "magic-string": {
@@ -5948,7 +5804,7 @@
       "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "dev": true,
       "requires": {
-        "vlq": "^0.2.2"
+        "vlq": "0.2.3"
       }
     },
     "make-dir": {
@@ -5957,7 +5813,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -5986,7 +5842,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "matcher": {
@@ -5995,7 +5851,7 @@
       "integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.4"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "math-random": {
@@ -6010,9 +5866,9 @@
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "dev": true,
       "requires": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "1.1.6"
       }
     },
     "media-typer": {
@@ -6027,16 +5883,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -6059,7 +5915,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       }
     },
     "methods": {
@@ -6074,19 +5930,19 @@
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.13",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "mime": {
@@ -6096,18 +5952,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.35.0"
       }
     },
     "mimic-fn": {
@@ -6128,7 +5984,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimatch-all": {
@@ -6137,7 +5993,7 @@
       "integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
       "dev": true,
       "requires": {
-        "minimatch": "^3.0.2"
+        "minimatch": "3.0.4"
       }
     },
     "minimist": {
@@ -6152,8 +6008,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -6162,7 +6018,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -6211,12 +6067,12 @@
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.2",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-flag": {
@@ -6231,7 +6087,7 @@
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -6249,19 +6105,19 @@
       "dev": true
     },
     "multer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.3.0.tgz",
-      "integrity": "sha1-CSsmcPaEb6SRSWXvyM+Uwg/sbNI=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.3.1.tgz",
+      "integrity": "sha512-JHdEoxkA/5NgZRo91RNn4UT+HdcJV9XUo01DTkKC7vo1erNIngtuaw9Y0WI8RdTlyi+wMIbunflhghzVLuGJyw==",
       "dev": true,
       "requires": {
-        "append-field": "^0.1.0",
-        "busboy": "^0.2.11",
-        "concat-stream": "^1.5.0",
-        "mkdirp": "^0.5.1",
-        "object-assign": "^3.0.0",
-        "on-finished": "^2.3.0",
-        "type-is": "^1.6.4",
-        "xtend": "^4.0.0"
+        "append-field": "0.1.0",
+        "busboy": "0.2.14",
+        "concat-stream": "1.6.2",
+        "mkdirp": "0.5.1",
+        "object-assign": "3.0.0",
+        "on-finished": "2.3.0",
+        "type-is": "1.6.16",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "object-assign": {
@@ -6278,8 +6134,8 @@
       "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
       "dev": true,
       "requires": {
-        "duplexer2": "^0.1.2",
-        "object-assign": "^4.1.0"
+        "duplexer2": "0.1.4",
+        "object-assign": "4.1.1"
       }
     },
     "mute-stream": {
@@ -6294,29 +6150,28 @@
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "requires": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
+        "any-promise": "1.3.0",
+        "object-assign": "4.1.1",
+        "thenify-all": "1.6.0"
       }
     },
     "nanomatch": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-odd": "^2.0.0",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "native-promise-only": {
@@ -6341,8 +6196,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
       "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "no-case": {
       "version": "2.3.2",
@@ -6350,16 +6204,7 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.1"
-      }
-    },
-    "nodegit-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nodegit-promise/-/nodegit-promise-4.0.0.tgz",
-      "integrity": "sha1-VyKxhPLfcycWEGSnkdLoQskWezQ=",
-      "dev": true,
-      "requires": {
-        "asap": "~2.0.3"
+        "lower-case": "1.1.4"
       }
     },
     "nomnom": {
@@ -6368,8 +6213,8 @@
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "dev": true,
       "requires": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
+        "chalk": "0.4.0",
+        "underscore": "1.6.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6384,9 +6229,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
+            "ansi-styles": "1.0.0",
+            "has-color": "0.1.7",
+            "strip-ansi": "0.1.1"
           }
         },
         "strip-ansi": {
@@ -6403,10 +6248,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -6415,7 +6260,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "npm-run-path": {
@@ -6424,7 +6269,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "number-is-nan": {
@@ -6457,9 +6302,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -6468,7 +6313,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "kind-of": {
@@ -6477,10 +6322,16 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
+    },
+    "object-keys": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -6488,7 +6339,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       }
     },
     "object.omit": {
@@ -6497,8 +6348,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -6507,7 +6358,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "obuf": {
@@ -6537,7 +6388,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -6546,7 +6397,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "opn": {
@@ -6555,7 +6406,7 @@
       "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
       "dev": true,
       "requires": {
-        "object-assign": "^4.0.1"
+        "object-assign": "4.1.1"
       }
     },
     "optimist": {
@@ -6564,8 +6415,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "wordwrap": {
@@ -6582,12 +6433,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "ordered-read-streams": {
@@ -6596,8 +6447,8 @@
       "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
       "dev": true,
       "requires": {
-        "is-stream": "^1.0.1",
-        "readable-stream": "^2.0.1"
+        "is-stream": "1.1.0",
+        "readable-stream": "2.3.6"
       }
     },
     "os-homedir": {
@@ -6618,8 +6469,8 @@
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "p-finally": {
@@ -6634,10 +6485,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.5.0"
       }
     },
     "param-case": {
@@ -6646,7 +6497,7 @@
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "parse-glob": {
@@ -6655,10 +6506,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "is-extglob": {
@@ -6673,7 +6524,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -6684,7 +6535,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.2"
       }
     },
     "parse-passwd": {
@@ -6705,7 +6556,7 @@
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseuri": {
@@ -6714,7 +6565,7 @@
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseurl": {
@@ -6741,7 +6592,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -6780,9 +6631,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "pathval": {
@@ -6797,10 +6648,10 @@
       "integrity": "sha512-mm8gLf4ZCaY6Qdm8J4bBdHs6SO4px71FspxgC2jJ0vXf3PYNZnGhU9zITCxpzFHpLPHsHU3xRBbuXNxEWuWziQ==",
       "dev": true,
       "requires": {
-        "md5": "^2.2.1",
-        "os-tmpdir": "^1.0.1",
-        "safe-buffer": "^5.1.1",
-        "which": "^1.2.4"
+        "md5": "2.2.1",
+        "os-tmpdir": "1.0.2",
+        "safe-buffer": "5.1.2",
+        "which": "1.3.1"
       }
     },
     "pend": {
@@ -6834,7 +6685,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "plist": {
@@ -6846,7 +6697,7 @@
       "requires": {
         "base64-js": "1.2.0",
         "xmlbuilder": "8.2.2",
-        "xmldom": "0.1.x"
+        "xmldom": "0.1.27"
       }
     },
     "pluralize": {
@@ -6861,9 +6712,9 @@
       "integrity": "sha1-yXbrodgNLdmRAF18EQ2vh0FUeI8=",
       "dev": true,
       "requires": {
-        "@types/node": "^4.2.3",
-        "@types/winston": "^2.2.0",
-        "winston": "^2.2.0"
+        "@types/node": "4.2.23",
+        "@types/winston": "2.3.9",
+        "winston": "2.4.3"
       },
       "dependencies": {
         "@types/node": {
@@ -6875,49 +6726,49 @@
       }
     },
     "polymer-analyzer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.1.tgz",
-      "integrity": "sha512-s1fEMUeUHs7EWZQ5cxL/RL6qzDcYnkJcLeQbNvVD1qOPtxRejGeonq5xsxmb8o7mstzSYb1x0Iba2Bdbfr+PAQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.1.0.tgz",
+      "integrity": "sha512-TW+SE+dofxSU6+7vJeH//Znjtu1brYE+J4w6M8W+BwoC3FHtBonxp4zCQFf+RnhQGcKIrfHVAxgujzccXer19Q==",
       "dev": true,
       "requires": {
-        "@babel/generator": "^7.0.0-beta.42",
-        "@babel/traverse": "^7.0.0-beta.42",
-        "@babel/types": "^7.0.0-beta.42",
-        "@types/babel-generator": "^6.25.1",
-        "@types/babel-traverse": "^6.25.2",
-        "@types/babel-types": "^6.25.1",
-        "@types/babylon": "^6.16.2",
-        "@types/chai-subset": "^1.3.0",
-        "@types/chalk": "^0.4.30",
-        "@types/clone": "^0.1.30",
-        "@types/cssbeautify": "^0.3.1",
-        "@types/doctrine": "^0.0.1",
-        "@types/is-windows": "^0.2.0",
-        "@types/minimatch": "^3.0.1",
-        "@types/node": "^9.6.4",
-        "@types/parse5": "^2.2.34",
-        "@types/path-is-inside": "^1.0.0",
+        "@babel/generator": "7.0.0-beta.54",
+        "@babel/traverse": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54",
+        "@types/babel-generator": "6.25.2",
+        "@types/babel-traverse": "6.25.4",
+        "@types/babel-types": "6.25.2",
+        "@types/babylon": "6.16.3",
+        "@types/chai-subset": "1.3.1",
+        "@types/chalk": "0.4.31",
+        "@types/clone": "0.1.30",
+        "@types/cssbeautify": "0.3.1",
+        "@types/doctrine": "0.0.1",
+        "@types/is-windows": "0.2.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "9.6.23",
+        "@types/parse5": "2.2.34",
+        "@types/path-is-inside": "1.0.0",
         "@types/resolve": "0.0.6",
-        "@types/whatwg-url": "^6.4.0",
-        "babylon": "^7.0.0-beta.42",
-        "cancel-token": "^0.1.1",
-        "chalk": "^1.1.3",
-        "clone": "^2.0.0",
-        "cssbeautify": "^0.3.1",
-        "doctrine": "^2.0.2",
-        "dom5": "^3.0.0",
+        "@types/whatwg-url": "6.4.0",
+        "babylon": "7.0.0-beta.47",
+        "cancel-token": "0.1.1",
+        "chalk": "1.1.3",
+        "clone": "2.1.1",
+        "cssbeautify": "0.3.1",
+        "doctrine": "2.1.0",
+        "dom5": "3.0.1",
         "indent": "0.0.2",
-        "is-windows": "^1.0.2",
-        "jsonschema": "^1.1.0",
-        "minimatch": "^3.0.4",
-        "parse5": "^4.0.0",
-        "path-is-inside": "^1.0.2",
-        "resolve": "^1.5.0",
-        "shady-css-parser": "^0.1.0",
-        "stable": "^0.1.6",
-        "strip-indent": "^2.0.0",
-        "vscode-uri": "^1.0.1",
-        "whatwg-url": "^6.4.0"
+        "is-windows": "1.0.2",
+        "jsonschema": "1.2.4",
+        "minimatch": "3.0.4",
+        "parse5": "4.0.0",
+        "path-is-inside": "1.0.2",
+        "resolve": "1.8.1",
+        "shady-css-parser": "0.1.0",
+        "stable": "0.1.8",
+        "strip-indent": "2.0.0",
+        "vscode-uri": "1.0.5",
+        "whatwg-url": "6.5.0"
       },
       "dependencies": {
         "chalk": {
@@ -6926,11 +6777,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "strip-ansi": {
@@ -6939,83 +6790,83 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
     },
     "polymer-build": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/polymer-build/-/polymer-build-3.0.1.tgz",
-      "integrity": "sha512-XnNP9M/fUbwYYOPijMK6t+o9DOjO8kpj2rm6irefA00TGfaQXHZhgPpT0zdd5xjAyAcZ4lpaLGcjIcCLY5mkgg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/polymer-build/-/polymer-build-3.0.4.tgz",
+      "integrity": "sha512-YSppvctpcO2do3XHXNo2WnD4mxpzTpjgLlByPXE0Jfz9N+Ez6EGmge7Xwd6NsFH9ch6IMyV1P9H238I/C/KZRw==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.0.0-beta.46",
-        "@babel/plugin-external-helpers": "^7.0.0-beta.46",
-        "@babel/plugin-proposal-async-generator-functions": "^7.0.0-beta.46",
-        "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.46",
-        "@babel/plugin-syntax-async-generators": "^7.0.0-beta.46",
-        "@babel/plugin-syntax-dynamic-import": "^7.0.0-beta.46",
-        "@babel/plugin-syntax-import-meta": "^7.0.0-beta.46",
-        "@babel/plugin-syntax-object-rest-spread": "^7.0.0-beta.46",
-        "@babel/plugin-transform-arrow-functions": "^7.0.0-beta.46",
-        "@babel/plugin-transform-async-to-generator": "^7.0.0-beta.46",
-        "@babel/plugin-transform-block-scoped-functions": "^7.0.0-beta.46",
-        "@babel/plugin-transform-block-scoping": "^7.0.0-beta.46",
-        "@babel/plugin-transform-classes": "=7.0.0-beta.35",
-        "@babel/plugin-transform-computed-properties": "^7.0.0-beta.46",
-        "@babel/plugin-transform-destructuring": "^7.0.0-beta.46",
-        "@babel/plugin-transform-duplicate-keys": "^7.0.0-beta.46",
-        "@babel/plugin-transform-exponentiation-operator": "^7.0.0-beta.46",
-        "@babel/plugin-transform-for-of": "^7.0.0-beta.46",
-        "@babel/plugin-transform-function-name": "^7.0.0-beta.46",
-        "@babel/plugin-transform-instanceof": "^7.0.0-beta.46",
-        "@babel/plugin-transform-literals": "^7.0.0-beta.46",
-        "@babel/plugin-transform-modules-amd": "^7.0.0-beta.46",
-        "@babel/plugin-transform-object-super": "^7.0.0-beta.46",
-        "@babel/plugin-transform-parameters": "^7.0.0-beta.46",
-        "@babel/plugin-transform-regenerator": "^7.0.0-beta.46",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0-beta.46",
-        "@babel/plugin-transform-spread": "^7.0.0-beta.46",
-        "@babel/plugin-transform-sticky-regex": "^7.0.0-beta.46",
-        "@babel/plugin-transform-template-literals": "^7.0.0-beta.46",
-        "@babel/plugin-transform-typeof-symbol": "^7.0.0-beta.46",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0-beta.46",
-        "@babel/traverse": "^7.0.0-beta.46",
-        "@polymer/esm-amd-loader": "^1.0.0",
-        "@types/babel-types": "^6.25.1",
-        "@types/babylon": "^6.16.2",
+        "@babel/core": "7.0.0-beta.54",
+        "@babel/plugin-external-helpers": "7.0.0-beta.54",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.54",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.54",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.54",
+        "@babel/plugin-syntax-dynamic-import": "7.0.0-beta.54",
+        "@babel/plugin-syntax-import-meta": "7.0.0-beta.54",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.54",
+        "@babel/plugin-transform-arrow-functions": "7.0.0-beta.54",
+        "@babel/plugin-transform-async-to-generator": "7.0.0-beta.54",
+        "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.54",
+        "@babel/plugin-transform-block-scoping": "7.0.0-beta.54",
+        "@babel/plugin-transform-classes": "7.0.0-beta.35",
+        "@babel/plugin-transform-computed-properties": "7.0.0-beta.54",
+        "@babel/plugin-transform-destructuring": "7.0.0-beta.54",
+        "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.54",
+        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.54",
+        "@babel/plugin-transform-for-of": "7.0.0-beta.54",
+        "@babel/plugin-transform-function-name": "7.0.0-beta.54",
+        "@babel/plugin-transform-instanceof": "7.0.0-beta.54",
+        "@babel/plugin-transform-literals": "7.0.0-beta.54",
+        "@babel/plugin-transform-modules-amd": "7.0.0-beta.54",
+        "@babel/plugin-transform-object-super": "7.0.0-beta.54",
+        "@babel/plugin-transform-parameters": "7.0.0-beta.54",
+        "@babel/plugin-transform-regenerator": "7.0.0-beta.54",
+        "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.54",
+        "@babel/plugin-transform-spread": "7.0.0-beta.54",
+        "@babel/plugin-transform-sticky-regex": "7.0.0-beta.54",
+        "@babel/plugin-transform-template-literals": "7.0.0-beta.54",
+        "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.54",
+        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.54",
+        "@babel/traverse": "7.0.0-beta.54",
+        "@polymer/esm-amd-loader": "1.0.2",
+        "@types/babel-types": "6.25.2",
+        "@types/babylon": "6.16.3",
         "@types/gulp-if": "0.0.33",
-        "@types/html-minifier": "^3.5.1",
-        "@types/is-windows": "^0.2.0",
+        "@types/html-minifier": "3.5.2",
+        "@types/is-windows": "0.2.0",
         "@types/mz": "0.0.31",
-        "@types/node": "^9.6.4",
-        "@types/parse5": "^2.2.34",
+        "@types/node": "9.6.23",
+        "@types/parse5": "2.2.34",
         "@types/resolve": "0.0.7",
-        "@types/uuid": "^3.4.3",
-        "@types/vinyl": "^2.0.0",
-        "@types/vinyl-fs": "^2.4.8",
-        "babel-plugin-minify-guarded-expressions": "=0.4.1",
-        "babel-preset-minify": "=0.4.0-alpha.caaefb4c",
-        "babylon": "^7.0.0-beta.42",
-        "css-slam": "^2.1.1",
-        "dom5": "^3.0.0",
-        "gulp-if": "^2.0.2",
-        "html-minifier": "^3.5.10",
-        "matcher": "^1.1.0",
-        "multipipe": "^1.0.2",
-        "mz": "^2.6.0",
-        "parse5": "^4.0.0",
-        "plylog": "^0.5.0",
-        "polymer-analyzer": "^3.0.0",
-        "polymer-bundler": "^4.0.0",
-        "polymer-project-config": "^4.0.0",
-        "regenerator-runtime": "^0.11.1",
+        "@types/uuid": "3.4.3",
+        "@types/vinyl": "2.0.2",
+        "@types/vinyl-fs": "2.4.8",
+        "babel-plugin-minify-guarded-expressions": "0.4.1",
+        "babel-preset-minify": "0.4.0-alpha.caaefb4c",
+        "babylon": "7.0.0-beta.47",
+        "css-slam": "2.1.2",
+        "dom5": "3.0.1",
+        "gulp-if": "2.0.2",
+        "html-minifier": "3.5.19",
+        "matcher": "1.1.1",
+        "multipipe": "1.0.2",
+        "mz": "2.7.0",
+        "parse5": "4.0.0",
+        "plylog": "0.5.0",
+        "polymer-analyzer": "3.1.0",
+        "polymer-bundler": "4.0.2",
+        "polymer-project-config": "4.0.2",
+        "regenerator-runtime": "0.11.1",
         "stream": "0.0.2",
-        "sw-precache": "^5.1.1",
-        "uuid": "^3.2.1",
-        "vinyl": "^1.2.0",
-        "vinyl-fs": "^2.4.4"
+        "sw-precache": "5.2.1",
+        "uuid": "3.3.2",
+        "vinyl": "1.2.0",
+        "vinyl-fs": "2.4.4"
       },
       "dependencies": {
         "@types/mz": {
@@ -7024,7 +6875,7 @@
           "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "9.6.23"
           }
         },
         "@types/resolve": {
@@ -7033,205 +6884,170 @@
           "integrity": "sha512-GPewdjkb0Q76o459qgp6pBLzJj/bD3oveS2kfLhIkZ9U3t3AFKtl5DlFB6lGTw0iZmcmxoGC8lpLW3NNJKrN9A==",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "9.6.23"
           }
         }
       }
     },
     "polymer-bundler": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-4.0.1.tgz",
-      "integrity": "sha512-nG+mpWn5h6nflOqZwtcpIKlYxXMznKFODa5XMQsUgD2126BT5cdznbMXCkH9vCIpbV5iBm5lCunmTyoYF+3BqA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-4.0.2.tgz",
+      "integrity": "sha512-eH+MNSVb/bCqchxYE1gVtdLP9eq1pLsr9NdcHhiJGEgSoZOYq7lGm2M/L7DHGJqa1/OqC7ZC9Sz3eQKAB8FaJQ==",
       "dev": true,
       "requires": {
-        "@types/acorn": "^4.0.3",
-        "@types/babel-generator": "^6.25.1",
-        "@types/babel-traverse": "^6.25.3",
-        "acorn-import-meta": "^0.2.1",
-        "babel-generator": "^6.26.1",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "clone": "^2.1.0",
-        "command-line-args": "^3.0.1",
-        "command-line-usage": "^3.0.3",
-        "dom5": "^2.2.0",
-        "espree": "^3.5.2",
-        "magic-string": "^0.22.4",
-        "mkdirp": "^0.5.1",
-        "parse5": "^2.2.2",
-        "polymer-analyzer": "^3.0.1",
-        "rollup": "^0.58.2",
-        "source-map": "^0.5.6",
-        "vscode-uri": "^1.0.1"
+        "@types/acorn": "4.0.3",
+        "@types/babel-generator": "6.25.2",
+        "@types/babel-traverse": "6.25.4",
+        "acorn-import-meta": "0.2.1",
+        "babel-generator": "6.26.1",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "clone": "2.1.1",
+        "command-line-args": "5.0.2",
+        "command-line-usage": "5.0.5",
+        "dom5": "3.0.1",
+        "espree": "3.5.4",
+        "magic-string": "0.22.5",
+        "mkdirp": "0.5.1",
+        "parse5": "4.0.0",
+        "polymer-analyzer": "3.1.0",
+        "rollup": "0.58.2",
+        "source-map": "0.5.7",
+        "vscode-uri": "1.0.5"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "6.0.112",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.112.tgz",
-          "integrity": "sha512-HnekQWq9t3Gl5aBYYi8sGyOWm85M5ub2llMrpQkRY94eJEUhsUr8qYNaeefv22cxxm+D67a+5zIzpl+dpFxdjQ==",
-          "dev": true
-        },
-        "dom5": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/dom5/-/dom5-2.3.0.tgz",
-          "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
           "dev": true,
           "requires": {
-            "@types/clone": "^0.1.29",
-            "@types/node": "^6.0.0",
-            "@types/parse5": "^2.2.32",
-            "clone": "^2.1.0",
-            "parse5": "^2.2.2"
+            "acorn": "3.3.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+              "dev": true
+            }
           }
         },
-        "parse5": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
-          "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=",
-          "dev": true
+        "espree": {
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.7.1",
+            "acorn-jsx": "3.0.1"
+          }
         }
       }
     },
     "polymer-project-config": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-4.0.1.tgz",
-      "integrity": "sha512-NJjP5gf6tOQ5YY8u0UM3hzrXPF2hpNIIyXCtd5VNCYoRGJdT//UFubyWFDd9Aje09yNWjS1SAfjZIhMgZ5DESg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-4.0.2.tgz",
+      "integrity": "sha512-nnxLkbpYYPIVBYooeercovQIWqq4coHzQ5PwK2+NxNpVWUJ5tW3OCDt46dqw3CtJNe4r/qIOkPgBJdVwXAAEmw==",
       "dev": true,
       "requires": {
-        "@types/node": "^9.6.4",
-        "browser-capabilities": "^1.0.0",
-        "jsonschema": "^1.1.1",
-        "minimatch-all": "^1.1.0",
-        "plylog": "^0.5.0"
+        "@types/node": "9.6.23",
+        "browser-capabilities": "1.1.1",
+        "jsonschema": "1.2.4",
+        "minimatch-all": "1.1.0",
+        "plylog": "0.5.0"
       }
     },
     "polyserve": {
-      "version": "0.27.11",
-      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.27.11.tgz",
-      "integrity": "sha512-C6laEBzDawtKzJEojv2wjUbuu66fNFEOfHsbHztrw0jn0CZsaV1okWEuFczgMNgW5ZL+Eg+QC4hzsHNA1dZZaw==",
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.27.12.tgz",
+      "integrity": "sha512-P4lb0fNqkSSRHrKTp9/bUnTjZOmnNnLWJ5zMBiWjkkJe3vzNcRpdL0vMQO6RxZ8MUvBI2Iv9mqGPVPY+Dk+Z1w==",
       "dev": true,
       "requires": {
-        "@types/compression": "^0.0.33",
-        "@types/content-type": "^1.1.0",
+        "@types/compression": "0.0.33",
+        "@types/content-type": "1.1.2",
         "@types/escape-html": "0.0.20",
-        "@types/express": "^4.0.36",
-        "@types/mime": "0.0.29",
+        "@types/express": "4.16.0",
+        "@types/mime": "2.0.0",
         "@types/mz": "0.0.29",
-        "@types/node": "^9.6.4",
-        "@types/opn": "^3.0.28",
-        "@types/parse5": "^2.2.34",
-        "@types/pem": "^1.8.1",
+        "@types/node": "9.6.23",
+        "@types/opn": "3.0.28",
+        "@types/parse5": "2.2.34",
+        "@types/pem": "1.9.3",
         "@types/resolve": "0.0.6",
-        "@types/serve-static": "^1.7.31",
-        "@types/spdy": "^3.4.1",
-        "bower-config": "^1.4.1",
-        "browser-capabilities": "^1.0.0",
-        "command-line-args": "^3.0.1",
-        "command-line-usage": "^3.0.3",
-        "compression": "^1.6.2",
-        "content-type": "^1.0.2",
-        "escape-html": "^1.0.3",
-        "express": "^4.8.5",
-        "find-port": "^1.0.1",
-        "http-proxy-middleware": "^0.17.2",
-        "lru-cache": "^4.0.2",
-        "mime": "^1.3.4",
-        "mz": "^2.4.0",
-        "opn": "^3.0.2",
-        "pem": "^1.8.3",
-        "polymer-build": "^3.0.0",
-        "polymer-project-config": "^4.0.0",
-        "requirejs": "^2.3.4",
-        "resolve": "^1.5.0",
-        "send": "^0.14.1",
-        "spdy": "^3.3.3"
+        "@types/serve-static": "1.13.2",
+        "@types/spdy": "3.4.4",
+        "bower-config": "1.4.1",
+        "browser-capabilities": "1.1.1",
+        "command-line-args": "5.0.2",
+        "command-line-usage": "5.0.5",
+        "compression": "1.7.3",
+        "content-type": "1.0.4",
+        "escape-html": "1.0.3",
+        "express": "4.16.3",
+        "find-port": "1.0.1",
+        "http-proxy-middleware": "0.17.4",
+        "lru-cache": "4.1.3",
+        "mime": "2.3.1",
+        "mz": "2.7.0",
+        "opn": "3.0.3",
+        "pem": "1.12.5",
+        "polymer-build": "3.0.4",
+        "polymer-project-config": "4.0.2",
+        "requirejs": "2.3.5",
+        "resolve": "1.8.1",
+        "send": "0.16.2",
+        "spdy": "3.4.7"
       },
       "dependencies": {
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-              "dev": true
-            }
+            "ms": "2.0.0"
           }
         },
-        "etag": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-          "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg=",
-          "dev": true
-        },
-        "fresh": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-          "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=",
-          "dev": true
-        },
-        "http-errors": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
-          "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "setprototypeof": "1.0.2",
-            "statuses": ">= 1.3.1 < 2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+        "mime": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
           "dev": true
         },
         "send": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.14.2.tgz",
-          "integrity": "sha1-ObBDiz9RC+Xcb2Z6EfcWiTaM3u8=",
+          "version": "0.16.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+          "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
           "dev": true,
           "requires": {
-            "debug": "~2.2.0",
-            "depd": "~1.1.0",
-            "destroy": "~1.0.4",
-            "encodeurl": "~1.0.1",
-            "escape-html": "~1.0.3",
-            "etag": "~1.7.0",
-            "fresh": "0.3.0",
-            "http-errors": "~1.5.1",
-            "mime": "1.3.4",
-            "ms": "0.7.2",
-            "on-finished": "~2.3.0",
-            "range-parser": "~1.2.0",
-            "statuses": "~1.3.1"
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "1.6.3",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.4.0"
           },
           "dependencies": {
             "mime": {
-              "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-              "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+              "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
               "dev": true
             }
           }
         },
-        "setprototypeof": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
-          "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg=",
-          "dev": true
-        },
         "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
       }
@@ -7284,24 +7100,14 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
-    "promisify-node": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/promisify-node/-/promisify-node-0.4.0.tgz",
-      "integrity": "sha1-MoA4dOxBF4TkeGwzmQKoeheaRpw=",
-      "dev": true,
-      "requires": {
-        "nodegit-promise": "~4.0.0",
-        "object-assign": "^4.0.1"
-      }
-    },
     "proxy-addr": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
-      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "dev": true,
       "requires": {
-        "forwarded": "~0.1.2",
-        "ipaddr.js": "1.6.0"
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.8.0"
       }
     },
     "pseudomap": {
@@ -7335,9 +7141,9 @@
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -7364,17 +7170,6 @@
         "http-errors": "1.6.3",
         "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.23",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        }
       }
     },
     "rc": {
@@ -7383,18 +7178,12 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
-        "deep-extend": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-          "dev": true
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -7409,9 +7198,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -7420,23 +7209,23 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       }
     },
     "readable-stream": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.0.3",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "redent": {
@@ -7445,8 +7234,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       },
       "dependencies": {
         "strip-indent": {
@@ -7455,7 +7244,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1"
+            "get-stdin": "4.0.1"
           }
         }
       }
@@ -7473,12 +7262,12 @@
       "dev": true
     },
     "regenerate-unicode-properties": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-6.0.0.tgz",
-      "integrity": "sha512-BvXxRS7RfVWxtm7vrq+0I0j7sqZ1zeSC+yzf5HS0qLnKcZPX541gFEGB39LvGuKHrkyKXrzXug+oC7xkM1Zovw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
+      "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.3.3"
+        "regenerate": "1.4.0"
       }
     },
     "regenerator-runtime": {
@@ -7488,12 +7277,12 @@
       "dev": true
     },
     "regenerator-transform": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.4.tgz",
-      "integrity": "sha512-p2I0fY+TbSLD2/VFTFb/ypEHxs3e3AjU0DzttdPqk2bSmDhfSh5E54b86Yc6XhUa5KykK1tgbvZ4Nr82oCJWkQ==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
+      "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
       "dev": true,
       "requires": {
-        "private": "^0.1.6"
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -7502,7 +7291,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -7511,8 +7300,17 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2"
       }
     },
     "regexpp": {
@@ -7522,17 +7320,17 @@
       "dev": true
     },
     "regexpu-core": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.5.tgz",
-      "integrity": "sha512-3xo5pFze1F8oR4F9x3aFbdtdxAxQ9WBX6gXfLgeBt7KpDI0+oDF7WVntnhsPKqobU/GAYc2pmx+y3z0JI1+z3w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
+      "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^6.0.0",
-        "regjsgen": "^0.4.0",
-        "regjsparser": "^0.3.0",
-        "unicode-match-property-ecmascript": "^1.0.3",
-        "unicode-match-property-value-ecmascript": "^1.0.1"
+        "regenerate": "1.4.0",
+        "regenerate-unicode-properties": "7.0.0",
+        "regjsgen": "0.4.0",
+        "regjsparser": "0.3.0",
+        "unicode-match-property-ecmascript": "1.0.4",
+        "unicode-match-property-value-ecmascript": "1.0.2"
       }
     },
     "registry-auth-token": {
@@ -7541,8 +7339,8 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "1.2.8",
+        "safe-buffer": "5.1.2"
       }
     },
     "registry-url": {
@@ -7551,7 +7349,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "1.2.8"
       }
     },
     "regjsgen": {
@@ -7566,7 +7364,7 @@
       "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -7607,7 +7405,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "replace-ext": {
@@ -7623,26 +7421,26 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.19",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       }
     },
     "require-uncached": {
@@ -7651,8 +7449,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       }
     },
     "requirejs": {
@@ -7668,12 +7466,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-dir": {
@@ -7682,8 +7480,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-from": {
@@ -7704,8 +7502,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "ret": {
@@ -7720,7 +7518,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "rollup": {
@@ -7730,7 +7528,7 @@
       "dev": true,
       "requires": {
         "@types/estree": "0.0.38",
-        "@types/node": "*"
+        "@types/node": "9.6.23"
       },
       "dependencies": {
         "@types/estree": {
@@ -7747,28 +7545,22 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
-    },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+    "rxjs": {
+      "version": "5.5.11",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
+      "integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
       "dev": true,
       "requires": {
-        "rx-lite": "*"
+        "symbol-observable": "1.0.1"
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "safe-regex": {
@@ -7777,7 +7569,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -7787,9 +7579,9 @@
       "dev": true
     },
     "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
       "dev": true
     },
     "sauce-connect-launcher": {
@@ -7799,32 +7591,21 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "adm-zip": "~0.4.3",
-        "async": "^2.1.2",
-        "https-proxy-agent": "^2.2.1",
-        "lodash": "^4.16.6",
-        "rimraf": "^2.5.4"
+        "adm-zip": "0.4.11",
+        "async": "2.6.1",
+        "https-proxy-agent": "2.2.1",
+        "lodash": "4.17.10",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-          "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-          "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "agent-base": "^4.1.0",
-            "debug": "^3.1.0"
+            "lodash": "4.17.10"
           }
         }
       }
@@ -7836,39 +7617,35 @@
       "dev": true
     },
     "selenium-standalone": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-6.15.0.tgz",
-      "integrity": "sha512-SUEbbxo/IK2RsuPQ1QFgdyKXvxDYJUen6nR40zWL9P0FrqeuAXHNCWdtqnwbgGeoCxCVbPVzUsXfSKtjp2+j0g==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-6.15.1.tgz",
+      "integrity": "sha512-2VXqkcpd+RNJZwCp8UMmqubeSkLvscraRZtg2qdkXwoNNmx5Hu6uaOBy45VJNG6PiUJNZtBZQpnOUfNN2aD1EA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "async": "^2.1.4",
-        "commander": "^2.9.0",
-        "cross-spawn": "^6.0.0",
-        "debug": "^3.0.0",
-        "lodash": "^4.17.4",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
+        "async": "2.6.1",
+        "commander": "2.9.0",
+        "cross-spawn": "6.0.5",
+        "debug": "3.1.0",
+        "lodash": "4.17.10",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
         "progress": "2.0.0",
         "request": "2.87.0",
         "tar-stream": "1.6.1",
-        "urijs": "^1.18.4",
-        "which": "^1.2.12",
-        "yauzl": "^2.5.0"
+        "urijs": "1.19.1",
+        "which": "1.3.1",
+        "yauzl": "2.10.0"
       },
       "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lodash": "4.17.10"
           }
         },
         "minimist": {
@@ -7892,7 +7669,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "^5.0.3"
+        "semver": "5.5.0"
       }
     },
     "send": {
@@ -7901,16 +7678,16 @@
       "integrity": "sha1-G+q/1C+eJwn5kCivMHisErRwktU=",
       "dev": true,
       "requires": {
-        "debug": "~2.1.1",
-        "depd": "~1.0.0",
+        "debug": "2.1.3",
+        "depd": "1.0.1",
         "destroy": "1.0.3",
         "escape-html": "1.0.1",
-        "etag": "~1.5.1",
+        "etag": "1.5.1",
         "fresh": "0.2.4",
         "mime": "1.2.11",
         "ms": "0.7.0",
-        "on-finished": "~2.2.0",
-        "range-parser": "~1.0.2"
+        "on-finished": "2.2.1",
+        "range-parser": "1.0.3"
       },
       "dependencies": {
         "debug": {
@@ -7996,9 +7773,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       },
       "dependencies": {
@@ -8018,18 +7795,18 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "destroy": "~1.0.4",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "etag": "~1.8.1",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "~1.6.2",
+            "http-errors": "1.6.3",
             "mime": "1.4.1",
             "ms": "2.0.0",
-            "on-finished": "~2.3.0",
-            "range-parser": "~1.2.0",
-            "statuses": "~1.4.0"
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.4.0"
           }
         },
         "statuses": {
@@ -8058,10 +7835,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -8070,7 +7847,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -8093,7 +7870,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -8109,36 +7886,15 @@
       "dev": true
     },
     "sinon": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
-      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
       "dev": true,
       "requires": {
-        "diff": "^3.1.0",
-        "formatio": "1.2.0",
-        "lolex": "^1.6.0",
-        "native-promise-only": "^0.8.1",
-        "path-to-regexp": "^1.7.0",
-        "samsam": "^1.1.3",
-        "text-encoding": "0.6.4",
-        "type-detect": "^4.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "path-to-regexp": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-          "dev": true,
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        }
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": "0.11.0"
       }
     },
     "sinon-chai": {
@@ -8153,7 +7909,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
+        "is-fullwidth-code-point": "2.0.0"
       }
     },
     "snapdragon": {
@@ -8162,14 +7918,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.1"
       },
       "dependencies": {
         "debug": {
@@ -8187,7 +7943,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -8196,7 +7952,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -8207,9 +7963,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -8218,7 +7974,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -8227,7 +7983,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -8236,7 +7992,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -8245,9 +8001,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -8258,7 +8014,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -8267,7 +8023,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -8278,7 +8034,7 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "socket.io": {
@@ -8287,12 +8043,12 @@
       "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
       "dev": true,
       "requires": {
-        "debug": "~3.1.0",
-        "engine.io": "~3.2.0",
-        "has-binary2": "~1.0.2",
-        "socket.io-adapter": "~1.1.0",
+        "debug": "3.1.0",
+        "engine.io": "3.2.0",
+        "has-binary2": "1.0.3",
+        "socket.io-adapter": "1.1.1",
         "socket.io-client": "2.1.1",
-        "socket.io-parser": "~3.2.0"
+        "socket.io-parser": "3.2.0"
       }
     },
     "socket.io-adapter": {
@@ -8311,15 +8067,15 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "engine.io-client": "~3.2.0",
-        "has-binary2": "~1.0.2",
+        "debug": "3.1.0",
+        "engine.io-client": "3.2.1",
+        "has-binary2": "1.0.3",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.2.0",
+        "socket.io-parser": "3.2.0",
         "to-array": "0.1.4"
       }
     },
@@ -8330,7 +8086,7 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
+        "debug": "3.1.0",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -8354,11 +8110,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.1",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-url": {
@@ -8373,8 +8129,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -8389,8 +8145,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -8405,12 +8161,12 @@
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "handle-thing": "^1.2.5",
-        "http-deceiver": "^1.2.7",
-        "safe-buffer": "^5.0.1",
-        "select-hose": "^2.0.0",
-        "spdy-transport": "^2.0.18"
+        "debug": "2.6.9",
+        "handle-thing": "1.2.5",
+        "http-deceiver": "1.2.7",
+        "safe-buffer": "5.1.2",
+        "select-hose": "2.0.0",
+        "spdy-transport": "2.1.0"
       },
       "dependencies": {
         "debug": {
@@ -8430,13 +8186,13 @@
       "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "detect-node": "^2.0.3",
-        "hpack.js": "^2.1.6",
-        "obuf": "^1.1.1",
-        "readable-stream": "^2.2.9",
-        "safe-buffer": "^5.0.1",
-        "wbuf": "^1.7.2"
+        "debug": "2.6.9",
+        "detect-node": "2.0.3",
+        "hpack.js": "2.1.6",
+        "obuf": "1.1.2",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2",
+        "wbuf": "1.7.3"
       },
       "dependencies": {
         "debug": {
@@ -8456,7 +8212,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -8471,15 +8227,15 @@
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "stable": {
@@ -8500,8 +8256,8 @@
       "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "lodash": "^3.0.0"
+        "chalk": "1.1.3",
+        "lodash": "3.10.1"
       },
       "dependencies": {
         "chalk": {
@@ -8510,11 +8266,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "lodash": {
@@ -8529,7 +8285,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -8540,8 +8296,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -8550,7 +8306,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -8567,7 +8323,7 @@
       "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
       "dev": true,
       "requires": {
-        "emitter-component": "^1.1.1"
+        "emitter-component": "1.1.1"
       }
     },
     "stream-shift": {
@@ -8588,17 +8344,30 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      }
+    },
+    "string.prototype.matchall": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-2.0.0.tgz",
+      "integrity": "sha512-WoZ+B2ypng1dp4iFLF2kmZlwwlE19gmjgKuhL1FJfDgCREWb3ye3SDVHSzLH6bxfnvYmkCxbzkmWcQZHA4P//Q==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "regexp.prototype.flags": "1.2.0"
       }
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringstream": {
@@ -8613,7 +8382,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8630,7 +8399,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-bom-stream": {
@@ -8639,8 +8408,8 @@
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "strip-bom": "^2.0.0"
+        "first-chunk-stream": "1.0.0",
+        "strip-bom": "2.0.0"
       }
     },
     "strip-eof": {
@@ -8673,16 +8442,16 @@
       "integrity": "sha512-8FAy+BP/FXE+ILfiVTt+GQJ6UEf4CVHD9OfhzH0JX+3zoy2uFk7Vn9EfXASOtVmmIVbL3jE/W8Z66VgPSZcMhw==",
       "dev": true,
       "requires": {
-        "dom-urls": "^1.1.0",
-        "es6-promise": "^4.0.5",
-        "glob": "^7.1.1",
-        "lodash.defaults": "^4.2.0",
-        "lodash.template": "^4.4.0",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "pretty-bytes": "^4.0.2",
-        "sw-toolbox": "^3.4.0",
-        "update-notifier": "^2.3.0"
+        "dom-urls": "1.1.0",
+        "es6-promise": "4.2.4",
+        "glob": "7.1.2",
+        "lodash.defaults": "4.2.0",
+        "lodash.template": "4.4.0",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "pretty-bytes": "4.0.2",
+        "sw-toolbox": "3.6.0",
+        "update-notifier": "2.5.0"
       }
     },
     "sw-toolbox": {
@@ -8691,8 +8460,8 @@
       "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
       "dev": true,
       "requires": {
-        "path-to-regexp": "^1.0.1",
-        "serviceworker-cache-polyfill": "^4.0.0"
+        "path-to-regexp": "1.7.0",
+        "serviceworker-cache-polyfill": "4.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -8712,32 +8481,37 @@
         }
       }
     },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+      "dev": true
+    },
     "table": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "^5.2.3",
-        "ajv-keywords": "^2.1.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
+        "ajv": "6.5.2",
+        "ajv-keywords": "3.2.0",
+        "chalk": "2.4.1",
+        "lodash": "4.17.10",
         "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       }
     },
     "table-layout": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.3.0.tgz",
-      "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.4.tgz",
+      "integrity": "sha512-uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==",
       "dev": true,
       "requires": {
-        "array-back": "^1.0.3",
-        "core-js": "^2.4.1",
-        "deep-extend": "~0.4.1",
-        "feature-detect-es6": "^1.3.1",
-        "typical": "^2.6.0",
-        "wordwrapjs": "^2.0.0-0"
+        "array-back": "2.0.0",
+        "deep-extend": "0.6.0",
+        "lodash.padend": "4.6.1",
+        "typical": "2.6.1",
+        "wordwrapjs": "3.0.0"
       }
     },
     "tar-stream": {
@@ -8746,13 +8520,13 @@
       "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "dev": true,
       "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.1.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.0",
-        "xtend": "^4.0.0"
+        "bl": "1.2.2",
+        "buffer-alloc": "1.2.0",
+        "end-of-stream": "1.4.1",
+        "fs-constants": "1.0.0",
+        "readable-stream": "2.3.6",
+        "to-buffer": "1.1.1",
+        "xtend": "4.0.1"
       }
     },
     "temp": {
@@ -8762,8 +8536,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "os-tmpdir": "^1.0.0",
-        "rimraf": "~2.2.6"
+        "os-tmpdir": "1.0.2",
+        "rimraf": "2.2.8"
       },
       "dependencies": {
         "rimraf": {
@@ -8781,7 +8555,7 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
-        "execa": "^0.7.0"
+        "execa": "0.7.0"
       }
     },
     "ternary-stream": {
@@ -8790,20 +8564,20 @@
       "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
       "dev": true,
       "requires": {
-        "duplexify": "^3.5.0",
-        "fork-stream": "^0.0.4",
-        "merge-stream": "^1.0.0",
-        "through2": "^2.0.1"
+        "duplexify": "3.6.0",
+        "fork-stream": "0.0.4",
+        "merge-stream": "1.0.1",
+        "through2": "2.0.3"
       }
     },
     "test-value": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-      "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
+      "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
       "dev": true,
       "requires": {
-        "array-back": "^1.0.3",
-        "typical": "^2.6.0"
+        "array-back": "2.0.0",
+        "typical": "2.6.1"
       }
     },
     "text-encoding": {
@@ -8824,7 +8598,7 @@
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "dev": true,
       "requires": {
-        "any-promise": "^1.0.0"
+        "any-promise": "1.3.0"
       }
     },
     "thenify-all": {
@@ -8833,7 +8607,7 @@
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
-        "thenify": ">= 3.1.0 < 4"
+        "thenify": "3.3.0"
       }
     },
     "through": {
@@ -8848,8 +8622,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "through2-filter": {
@@ -8858,8 +8632,8 @@
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "dev": true,
       "requires": {
-        "through2": "~2.0.0",
-        "xtend": "~4.0.0"
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "timed-out": {
@@ -8874,7 +8648,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-absolute-glob": {
@@ -8883,7 +8657,7 @@
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1"
+        "extend-shallow": "2.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -8892,7 +8666,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -8921,7 +8695,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -8930,7 +8704,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -8941,10 +8715,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -8953,8 +8727,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       }
     },
     "tough-cookie": {
@@ -8963,7 +8737,7 @@
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -8980,7 +8754,7 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "trim-newlines": {
@@ -9001,7 +8775,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -9017,13 +8791,13 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
       "dev": true
     },
     "type-is": {
@@ -9033,7 +8807,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.19"
       }
     },
     "typedarray": {
@@ -9055,19 +8829,19 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.3.28",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.28.tgz",
-      "integrity": "sha512-68Rc/aA6cswiaQ5SrE979UJcXX+ADA1z33/ZsPd+fbAiVdjZ16OXdbtGO+rJUUBgK6qdf3SOPhQf3K/ybF5Miw==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.6.tgz",
+      "integrity": "sha512-O1D7L6WcOzS1qW2ehopEm4cWm5yA6bQBozlks8jO8ODxYCy4zv+bR/la4Lwp01tpkYGNonnpXvUpYtrvSu8Yzg==",
       "dev": true,
       "requires": {
-        "commander": "~2.15.0",
-        "source-map": "~0.6.1"
+        "commander": "2.16.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "version": "2.16.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+          "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
           "dev": true
         },
         "source-map": {
@@ -9090,42 +8864,32 @@
       "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
       "dev": true
     },
-    "underscore.string": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
-      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "^1.0.3",
-        "util-deprecate": "^1.0.2"
-      }
-    },
     "unicode-canonical-property-names-ecmascript": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.3.tgz",
-      "integrity": "sha512-iG/2t0F2LAU8aZYPkX5gi7ebukHnr3sWFESpb+zPQeeaQwOkfoO6ZW17YX7MdRPNG9pCy+tjzGill+Ah0Em0HA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
       "dev": true
     },
     "unicode-match-property-ecmascript": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.3.tgz",
-      "integrity": "sha512-nFcaBFcr08UQNF15ZgI5ISh3yUnQm7SJRRxwYrL5VYX46pS+6Q7TCTv4zbK+j6/l7rQt0mMiTL2zpmeygny6rA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "dev": true,
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.2",
-        "unicode-property-aliases-ecmascript": "^1.0.3"
+        "unicode-canonical-property-names-ecmascript": "1.0.4",
+        "unicode-property-aliases-ecmascript": "1.0.4"
       }
     },
     "unicode-match-property-value-ecmascript": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.1.tgz",
-      "integrity": "sha512-lM8B0FDZQh9yYGgiabRQcyWicB27VLOolSBRIxsO7FeQPtg+79Oe7sC8Mzr8BObDs+G9CeYmC/shHo6OggNEog==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
       "dev": true
     },
     "unicode-property-aliases-ecmascript": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.3.tgz",
-      "integrity": "sha512-TdDmDOTxEf2ad1g3ZBpM6cqKIb2nJpVlz1Q++casDryKz18tpeMBhSng9hjC1CTQCkOV9Rw2knlSB6iRo7ad1w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
       "dev": true
     },
     "union-value": {
@@ -9134,10 +8898,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -9146,7 +8910,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -9155,10 +8919,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -9169,8 +8933,8 @@
       "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "^1.0.0",
-        "through2-filter": "^2.0.0"
+        "json-stable-stringify": "1.0.1",
+        "through2-filter": "2.0.0"
       }
     },
     "unique-string": {
@@ -9179,7 +8943,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "^1.0.0"
+        "crypto-random-string": "1.0.0"
       }
     },
     "unpipe": {
@@ -9194,8 +8958,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -9204,9 +8968,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -9234,7 +8998,7 @@
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "unzip-response": {
@@ -9249,16 +9013,16 @@
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "dev": true,
       "requires": {
-        "boxen": "^1.2.1",
-        "chalk": "^2.0.1",
-        "configstore": "^3.0.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^1.0.10",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "boxen": "1.3.0",
+        "chalk": "2.4.1",
+        "configstore": "3.1.2",
+        "import-lazy": "2.1.0",
+        "is-ci": "1.1.0",
+        "is-installed-globally": "0.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "upper-case": {
@@ -9266,6 +9030,15 @@
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.1"
+      }
     },
     "urijs": {
       "version": "1.19.1",
@@ -9285,22 +9058,19 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "1.0.4"
       }
     },
     "use": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-      "dev": true,
-      "requires": {
-        "kind-of": "^6.0.2"
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.11.0.tgz",
+      "integrity": "sha512-5n12uMzKCjvB2HPFHnbQSjaqAa98L5iIXmHrZCLavuZVe0qe/SJGbDGWlpaHk5lnBkWRDO+dRu1/PgmUYKPPTw==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3"
@@ -9319,9 +9089,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
     "vali-date": {
@@ -9336,8 +9106,8 @@
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "vargs": {
@@ -9358,9 +9128,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vinyl": {
@@ -9369,8 +9139,8 @@
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
+        "clone": "1.0.4",
+        "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       },
       "dependencies": {
@@ -9388,23 +9158,23 @@
       "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
       "dev": true,
       "requires": {
-        "duplexify": "^3.2.0",
-        "glob-stream": "^5.3.2",
-        "graceful-fs": "^4.0.0",
+        "duplexify": "3.6.0",
+        "glob-stream": "5.3.5",
+        "graceful-fs": "4.1.11",
         "gulp-sourcemaps": "1.6.0",
-        "is-valid-glob": "^0.3.0",
-        "lazystream": "^1.0.0",
-        "lodash.isequal": "^4.0.0",
-        "merge-stream": "^1.0.0",
-        "mkdirp": "^0.5.0",
-        "object-assign": "^4.0.0",
-        "readable-stream": "^2.0.4",
-        "strip-bom": "^2.0.0",
-        "strip-bom-stream": "^1.0.0",
-        "through2": "^2.0.0",
-        "through2-filter": "^2.0.0",
-        "vali-date": "^1.0.0",
-        "vinyl": "^1.0.0"
+        "is-valid-glob": "0.3.0",
+        "lazystream": "1.0.0",
+        "lodash.isequal": "4.5.0",
+        "merge-stream": "1.0.1",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1",
+        "readable-stream": "2.3.6",
+        "strip-bom": "2.0.0",
+        "strip-bom-stream": "1.0.0",
+        "through2": "2.0.3",
+        "through2-filter": "2.0.0",
+        "vali-date": "1.0.0",
+        "vinyl": "1.2.0"
       }
     },
     "vlq": {
@@ -9414,9 +9184,9 @@
       "dev": true
     },
     "vscode-uri": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
-      "integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.5.tgz",
+      "integrity": "sha1-O4majvccN/MFTXm9vdoxx7828g0=",
       "dev": true
     },
     "wbuf": {
@@ -9425,7 +9195,7 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dev": true,
       "requires": {
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "1.0.1"
       }
     },
     "wct-browser-legacy": {
@@ -9434,203 +9204,76 @@
       "integrity": "sha512-+HmZ5C2WNksNcti41ZihUL5b8ms8q6mOanXKK2jm3aBTnx7vqtkvdFPVJUbapglLWC0RReScBbhT0YuYbdoEOw==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@polymer/sinonjs": "^1.14.1",
-        "@polymer/test-fixture": "^3.0.0-pre.1",
-        "@webcomponents/webcomponentsjs": "^2.0.0",
-        "accessibility-developer-tools": "^2.12.0",
-        "async": "^1.5.2",
-        "chai": "^3.5.0",
-        "lodash": "^3.10.1",
-        "mocha": "^3.4.2",
-        "sinon": "^1.17.1",
-        "sinon-chai": "^2.10.0",
-        "stacky": "^1.3.1"
+        "@polymer/polymer": "3.0.2",
+        "@polymer/sinonjs": "1.17.1",
+        "@polymer/test-fixture": "3.0.0-pre.21",
+        "@webcomponents/webcomponentsjs": "2.0.3",
+        "accessibility-developer-tools": "2.12.0",
+        "async": "1.5.2",
+        "chai": "3.5.0",
+        "lodash": "3.10.1",
+        "mocha": "3.5.3",
+        "sinon": "1.17.7",
+        "sinon-chai": "2.14.0",
+        "stacky": "1.3.1"
       },
       "dependencies": {
-        "@polymer/test-fixture": {
-          "version": "3.0.0-pre.19",
-          "resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-3.0.0-pre.19.tgz",
-          "integrity": "sha512-oyltfPEEPF8gzLxSv/CjieO9n0Uani567pcpmAk3IZeOMsFh9OFddZDYCwKx1e9I6lFe9557MaxQHM7EGhLaOQ==",
-          "dev": true
-        },
-        "@webcomponents/webcomponentsjs": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.0.0.tgz",
-          "integrity": "sha512-f6izmesHd8E+rL32tftlXZmz1EAL+lLn8AUex0mJFLe39z53iTFNCqxAYsMmCA/QSGP+8X6D1it/JbuVl1jOHA==",
-          "dev": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "chai": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-          "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-          "dev": true,
-          "requires": {
-            "assertion-error": "^1.0.1",
-            "deep-eql": "^0.1.3",
-            "type-detect": "^1.0.0"
-          }
-        },
-        "deep-eql": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-          "dev": true,
-          "requires": {
-            "type-detect": "0.1.1"
-          },
-          "dependencies": {
-            "type-detect": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-              "dev": true
-            }
-          }
-        },
-        "formatio": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-          "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-          "dev": true,
-          "requires": {
-            "samsam": "~1.1"
-          }
-        },
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "lolex": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-          "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
-          "dev": true
-        },
-        "samsam": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-          "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
-          "dev": true
-        },
-        "sinon": {
-          "version": "1.17.7",
-          "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
-          "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
-          "dev": true,
-          "requires": {
-            "formatio": "1.1.1",
-            "lolex": "1.3.2",
-            "samsam": "1.1.2",
-            "util": ">=0.10.3 <1"
-          }
-        },
-        "type-detect": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
           "dev": true
         }
       }
     },
     "wct-local": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wct-local/-/wct-local-2.1.0.tgz",
-      "integrity": "sha512-OiMSbxp6e5tyvTbUA4VAQbw4we53EXEmekx9BbIgS/HryoQISzap5DSAE/kvpRpJ2Axt0z12d8ChxqwNflApfA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/wct-local/-/wct-local-2.1.1.tgz",
+      "integrity": "sha512-U0qcIzsjl0vJ2KR5K766WVzJlmqfMRo8VqgRVQmrePGBsE40vj9hD+XiFw8yusamibZEWRU+DtVP3GKSwJz2EQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@types/express": "^4.0.30",
-        "@types/freeport": "^1.0.19",
-        "@types/launchpad": "^0.6.0",
-        "@types/node": "^9.3.0",
-        "@types/which": "^1.3.1",
-        "chalk": "^2.3.0",
-        "cleankill": "^2.0.0",
-        "freeport": "^1.0.4",
-        "launchpad": "^0.7.0",
-        "promisify-node": "^0.4.0",
-        "selenium-standalone": "^6.7.0",
-        "which": "^1.0.8"
+        "@types/express": "4.16.0",
+        "@types/freeport": "1.0.21",
+        "@types/launchpad": "0.6.0",
+        "@types/node": "9.6.23",
+        "@types/which": "1.3.1",
+        "chalk": "2.4.1",
+        "cleankill": "2.0.0",
+        "freeport": "1.0.5",
+        "launchpad": "0.7.0",
+        "selenium-standalone": "6.15.1",
+        "which": "1.3.1"
       }
     },
     "wct-sauce": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/wct-sauce/-/wct-sauce-2.0.1.tgz",
-      "integrity": "sha512-nk6cPKdACVt3R+n9XyCTQTeRKOhhajyh0WaF5U1BsxPlVS8tNOUGleXQDUUjB+q1DPS7+j1F3UJqhnmrUMDVJA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/wct-sauce/-/wct-sauce-2.0.3.tgz",
+      "integrity": "sha512-vR+gdd1RJjK6+UaiduNYxxNneIFLAwkpO7FlJR045q0Hguavvax2NvSLw+XibQdE0khQxmjsXSM/rq1bk2tYmg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "cleankill": "^2.0.0",
-        "lodash": "^3.0.1",
-        "request": "^2.85.0",
-        "sauce-connect-launcher": "^1.0.0",
-        "temp": "^0.8.1",
-        "uuid": "^2.0.1"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-          "dev": true,
-          "optional": true
-        }
+        "chalk": "2.4.1",
+        "cleankill": "2.0.0",
+        "lodash": "4.17.10",
+        "request": "2.87.0",
+        "sauce-connect-launcher": "1.2.4",
+        "temp": "0.8.3",
+        "uuid": "3.3.2"
       }
     },
     "wd": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/wd/-/wd-1.8.1.tgz",
-      "integrity": "sha512-kl8wgkD6L2VaI2ODPr6plsJuSo6jre2te4TgcMrzP3AZy5OPp76ZSsf34QmuSW1EhLqnOZ8u916wgOAYFdAj/w==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/wd/-/wd-1.10.3.tgz",
+      "integrity": "sha512-ffqqZDtFFLeg5u/4pw2vYKECW+z+vW6vc+7rcqF15uu1/rmw3BydV84BONNc9DIcQ5Z7gQFS/hAuMvj53eVtSg==",
       "dev": true,
       "requires": {
         "archiver": "2.1.1",
         "async": "2.0.1",
         "lodash": "4.17.10",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "0.5.1",
         "q": "1.4.1",
         "request": "2.85.0",
-        "underscore.string": "3.3.4",
         "vargs": "0.1.0"
       },
       "dependencies": {
@@ -9640,14 +9283,8 @@
           "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
           "dev": true,
           "requires": {
-            "lodash": "^4.8.0"
+            "lodash": "4.17.10"
           }
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
         },
         "q": {
           "version": "1.4.1",
@@ -9661,83 +9298,148 @@
           "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "hawk": "~6.0.2",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "stringstream": "~0.0.5",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.7.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.2",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.19",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.2",
+            "stringstream": "0.0.6",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.3.2"
           }
         }
       }
     },
     "web-component-tester": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/web-component-tester/-/web-component-tester-6.6.0.tgz",
-      "integrity": "sha512-f+LqR4rHUtVIg6T79uo6BYuyrIOzInPWzOJo69sGxX3tRTDeTwQzJSrfX4/MKA4qa3ldGPODJHizRYgZbjYjbQ==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/web-component-tester/-/web-component-tester-6.7.1.tgz",
+      "integrity": "sha512-i/N0MYLBh9fjzI4pcKvfYiTx4JEr+Zbt2m1/ANovpvT74El55WaiFyiwCdUGhnlX1xy1URGUB2CJgl6gdTBumg==",
       "dev": true,
       "requires": {
-        "@polymer/sinonjs": "^1.14.1",
-        "@polymer/test-fixture": "^0.0.3",
-        "@webcomponents/webcomponentsjs": "^1.0.7",
-        "accessibility-developer-tools": "^2.12.0",
-        "async": "^2.4.1",
-        "body-parser": "^1.17.2",
-        "bower-config": "^1.4.0",
-        "chai": "^4.0.2",
-        "chalk": "^1.1.3",
-        "cleankill": "^2.0.0",
-        "express": "^4.15.3",
-        "findup-sync": "^2.0.0",
-        "glob": "^7.1.2",
-        "lodash": "^3.10.1",
-        "mocha": "^3.4.2",
-        "multer": "^1.3.0",
-        "nomnom": "^1.8.1",
-        "polyserve": "^0.27.11",
-        "promisify-node": "^0.4.0",
-        "resolve": "^1.5.0",
-        "semver": "^5.3.0",
-        "send": "^0.11.1",
-        "server-destroy": "^1.0.1",
-        "sinon": "^2.3.5",
-        "sinon-chai": "^2.10.0",
-        "socket.io": "^2.0.3",
-        "stacky": "^1.3.1",
-        "update-notifier": "^2.2.0",
-        "wct-local": "^2.1.0",
-        "wct-sauce": "^2.0.0",
-        "wd": "^1.2.0"
+        "@polymer/sinonjs": "1.17.1",
+        "@polymer/test-fixture": "0.0.3",
+        "@webcomponents/webcomponentsjs": "1.2.3",
+        "accessibility-developer-tools": "2.12.0",
+        "async": "2.6.1",
+        "body-parser": "1.18.3",
+        "bower-config": "1.4.1",
+        "chai": "4.1.2",
+        "chalk": "1.1.3",
+        "cleankill": "2.0.0",
+        "express": "4.16.3",
+        "findup-sync": "2.0.0",
+        "glob": "7.1.2",
+        "lodash": "3.10.1",
+        "multer": "1.3.1",
+        "nomnom": "1.8.1",
+        "polyserve": "0.27.12",
+        "resolve": "1.8.1",
+        "semver": "5.5.0",
+        "send": "0.11.1",
+        "server-destroy": "1.0.1",
+        "sinon": "2.4.1",
+        "sinon-chai": "2.14.0",
+        "socket.io": "2.1.1",
+        "stacky": "1.3.1",
+        "update-notifier": "2.5.0",
+        "wct-local": "2.1.1",
+        "wct-sauce": "2.0.3",
+        "wd": "1.10.3"
       },
       "dependencies": {
+        "@polymer/test-fixture": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
+          "integrity": "sha1-REN1JpfU2Sk7vEEuoLXk00HxSdk=",
+          "dev": true
+        },
+        "@webcomponents/webcomponentsjs": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.2.3.tgz",
+          "integrity": "sha512-4ZdOi2UwNr2wZk+GX+Q98ew0R3aBTD61zXRVw3Oapow3JPDRY2OM6HH/kREYMAc1x2zRbp0AAd/OjfuqJ0oojg==",
+          "dev": true
+        },
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.10"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.10",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+              "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+              "dev": true
+            }
+          }
+        },
+        "chai": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+          "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+          "dev": true,
+          "requires": {
+            "assertion-error": "1.1.0",
+            "check-error": "1.0.2",
+            "deep-eql": "3.0.1",
+            "get-func-name": "2.0.0",
+            "pathval": "1.1.0",
+            "type-detect": "4.0.8"
+          }
+        },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
+        },
+        "deep-eql": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+          "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
+        "formatio": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+          "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+          "dev": true,
+          "requires": {
+            "samsam": "1.3.0"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         },
         "lodash": {
           "version": "3.10.1",
@@ -9745,14 +9447,57 @@
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        },
+        "samsam": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+          "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+          "dev": true
+        },
+        "sinon": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+          "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
+          "dev": true,
+          "requires": {
+            "diff": "3.2.0",
+            "formatio": "1.2.0",
+            "lolex": "1.6.0",
+            "native-promise-only": "0.8.1",
+            "path-to-regexp": "1.7.0",
+            "samsam": "1.3.0",
+            "text-encoding": "0.6.4",
+            "type-detect": "4.0.8"
+          }
+        },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+          "dev": true
         }
       }
     },
@@ -9763,23 +9508,23 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
-      "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
       }
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "widest-line": {
@@ -9788,21 +9533,21 @@
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       }
     },
     "winston": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.2.tgz",
-      "integrity": "sha512-4S/Ad4ZfSNl8OccCLxnJmNISWcm2joa6Q0YGDxlxMzH0fgSwWsjMt+SmlNwCqdpaPg3ev1HKkMBsIiXeSUwpbA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.3.tgz",
+      "integrity": "sha512-GYKuysPz2pxYAVJD2NPsDLP5Z79SDEzPm9/j4tCjkF/n89iBNGBMJcR+dMUqxgPNgoSs6fVygPi+Vl2oxIpBuw==",
       "dev": true,
       "requires": {
-        "async": "~1.0.0",
-        "colors": "1.0.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "stack-trace": "0.0.x"
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "stack-trace": "0.0.10"
       },
       "dependencies": {
         "async": {
@@ -9820,15 +9565,13 @@
       "dev": true
     },
     "wordwrapjs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-2.0.0.tgz",
-      "integrity": "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
+      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
       "dev": true,
       "requires": {
-        "array-back": "^1.0.3",
-        "feature-detect-es6": "^1.3.1",
-        "reduce-flatten": "^1.0.1",
-        "typical": "^2.6.0"
+        "reduce-flatten": "1.0.1",
+        "typical": "2.6.1"
       }
     },
     "wrappy": {
@@ -9843,7 +9586,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "write-file-atomic": {
@@ -9852,9 +9595,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "ws": {
@@ -9863,9 +9606,9 @@
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "dev": true,
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.2",
+        "ultron": "1.1.1"
       }
     },
     "xdg-basedir": {
@@ -9907,14 +9650,14 @@
       "dev": true
     },
     "yauzl": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.2.tgz",
-      "integrity": "sha1-T7G8euH8L1cDe1SvasyP4QMcW3c=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "optional": true,
       "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "buffer-crc32": "0.2.13",
+        "fd-slicer": "1.1.0"
       }
     },
     "yeast": {
@@ -9929,10 +9672,10 @@
       "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
       "dev": true,
       "requires": {
-        "archiver-utils": "^1.3.0",
-        "compress-commons": "^1.2.0",
-        "lodash": "^4.8.0",
-        "readable-stream": "^2.0.0"
+        "archiver-utils": "1.3.0",
+        "compress-commons": "1.2.2",
+        "lodash": "4.17.10",
+        "readable-stream": "2.3.6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
     "url": "https://github.com/webcomponents/template/issues"
   },
   "scripts": {
-    "test": "npm run lint && wct --npm",
-    "lint": "eslint template.js test/**/*.html"
+    "test": "npm run lint && wct",
+    "lint": "eslint template.js tests/**/*.html"
   },
   "homepage": "http://webcomponents.org",
   "devDependencies": {
-    "eslint": "^4.19.0",
+    "eslint": "^5.2.0",
     "eslint-plugin-html": "^4.0.3",
-    "web-component-tester": "^6.6.0",
-    "wct-browser-legacy": "^1.0.1"
+    "wct-browser-legacy": "^1.0.1",
+    "web-component-tester": "^6.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/template.js
+++ b/template.js
@@ -127,8 +127,31 @@
   var capturedAppendChild = Node.prototype.appendChild;
   var capturedReplaceChild = Node.prototype.replaceChild;
   var capturedParseFromString = DOMParser.prototype.parseFromString;
-  var capturedHTMLElementInnerHTML = Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, 'innerHTML');
-  var capturedChildNodes = Object.getOwnPropertyDescriptor(window.Node.prototype, 'childNodes');
+  var capturedHTMLElementInnerHTML = Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, 'innerHTML') || {
+    /**
+     * @this {!HTMLElement}
+     * @return {string}
+     */
+    get: function() {
+      return this.innerHTML;
+    },
+    /**
+     * @this {!HTMLElement}
+     * @param {string}
+     */
+    set: function(text) {
+      this.innerHTML = text;
+    }
+  };
+  var capturedChildNodes = Object.getOwnPropertyDescriptor(window.Node.prototype, 'childNodes') || {
+    /**
+     * @this {!Node}
+     * @return {!NodeList}
+     */
+    get: function() {
+      return this.childNodes;
+    }
+  };
 
   var elementQuerySelectorAll = Element.prototype.querySelectorAll;
   var docQuerySelectorAll = Document.prototype.querySelectorAll;

--- a/tests/basic.html
+++ b/tests/basic.html
@@ -41,7 +41,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var el = document.createElement('div');
           try {
             Object.defineProperty(el, 'innerHTML', {
-              get: function(){},
+              get: function(){}, // eslint-disable-line getter-return
               set: function(){}
             });
             return true;
@@ -387,7 +387,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var doc = document.implementation.createHTMLDocument('');
           var imp = doc.createElement('div');
           var t = document.createElement('template');
-          t.innerHTML = '<svg><template><circle cx="150" cy="150" r="100" fill="blue" /></template></svg>'
+          t.innerHTML = '<svg><template><circle cx="150" cy="150" r="100" fill="blue" /></template></svg>';
           imp.appendChild(t);
 
           var impClone = document.importNode(imp, true);
@@ -407,7 +407,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var doc = document.implementation.createHTMLDocument('');
           var imp = doc.createElement('div');
           var t = document.createElement('template');
-          t.innerHTML = '<svg><template><circle cx="150" cy="150" r="100" fill="blue" /></template></svg>'
+          t.innerHTML = '<svg><template><circle cx="150" cy="150" r="100" fill="blue" /></template></svg>';
           imp.appendChild(t);
 
           var impClone = imp.cloneNode(true);

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,5 +1,6 @@
 {
   "suites": ["tests/runner.html"],
+  "npm": true,
   "clientOptions": {
     "environmentImports": []
   },


### PR DESCRIPTION
- Some old browsers do not have `childNodes` and `innerHTML` getters on the
prototype, work around by using the magical instance version
- Update dependencies
- Fix lint errors in tests

Fixes #50